### PR TITLE
Add ability to insert Grid.RowDefinition

### DIFF
--- a/RapidXAML.VSIX/LocalizationHelper/LocHelperProgram.cs
+++ b/RapidXAML.VSIX/LocalizationHelper/LocHelperProgram.cs
@@ -178,7 +178,7 @@ namespace LocalizationHelper
 
         private static void CreateLocalizedPlaceholdersForNewNeutralStringresEntries()
         {
-
+            // TODO: implement CreateLocalizedPlaceholdersForNewNeutralStringresEntries
             // List locales being processed
             // List entries being created
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Grid/InsertRowDefinitionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Grid/InsertRowDefinitionTests.cs
@@ -1,0 +1,869 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Remoting.Messaging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Analyzers;
+using RapidXamlToolkit.Commands;
+using RapidXamlToolkit.Options;
+
+namespace RapidXamlToolkit.Tests.Grid
+{
+    [TestClass]
+    public class InsertRowDefinitionTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void CmdEnabledInFirstRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, true);
+        }
+
+        [TestMethod]
+        public void CmdEnabledInSecondRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition ☆Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, true);
+        }
+
+        [TestMethod]
+        public void CmdNotEnabledBeforeFirstRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>☆
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, false);
+        }
+
+        [TestMethod]
+        public void CmdNotEnabledAfterDefinitions()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+☆
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, false);
+        }
+
+        [TestMethod]
+        public void GetRowNumberForFirstRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <☆RowDefinition Height=""Auto"" /☆>
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.EachPositionBetweenStarsShouldReturnRowNumber(xaml, 0);
+        }
+
+        [TestMethod]
+        public void GetRowNumberForSecondRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <☆RowDefinition Height=""*"" /☆>
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.EachPositionBetweenStarsShouldReturnRowNumber(xaml, 1);
+        }
+
+        [TestMethod]
+        public void GetRowNumberForThirdRowDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <☆RowDefinition Height=""*"" /☆>
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.EachPositionBetweenStarsShouldReturnRowNumber(xaml, 2);
+        }
+
+        [TestMethod]
+        public void GetRowNumberForFirstRowDefinitionInNestedGrid()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""1"">
+            <Grid.RowDefinitions>
+                <☆RowDefinition Height=""Auto"" /☆>
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+    </Grid>
+</Page>";
+
+            this.EachPositionBetweenStarsShouldReturnRowNumber(xaml, 0);
+        }
+
+        [TestMethod]
+        public void GetExpectedReplacementsFromFirstDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = new List<(string, string)>
+            {
+                (" Grid.Row=\"6\"", " Grid.Row=\"7\""),
+                (" Grid.Row=\"5\"", " Grid.Row=\"6\""),
+                (" Grid.Row=\"4\"", " Grid.Row=\"5\""),
+                (" Grid.Row=\"3\"", " Grid.Row=\"4\""),
+                (" Grid.Row=\"2\"", " Grid.Row=\"3\""),
+                (" Grid.Row=\"1\"", " Grid.Row=\"2\""),
+                (" Grid.Row=\"0\"", " Grid.Row=\"1\""),
+            };
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetExpectedReplacementsFromMiddleDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = new List<(string, string)>
+            {
+                (" Grid.Row=\"6\"", " Grid.Row=\"7\""),
+                (" Grid.Row=\"5\"", " Grid.Row=\"6\""),
+                (" Grid.Row=\"4\"", " Grid.Row=\"5\""),
+                (" Grid.Row=\"3\"", " Grid.Row=\"4\""),
+                (" Grid.Row=\"2\"", " Grid.Row=\"3\""),
+                (" Grid.Row=\"1\"", " Grid.Row=\"2\""),
+            };
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetExpectedReplacementsFromLastDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition Height=""*"" />
+            <RowDefinition ☆Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = new List<(string, string)>
+            {
+                (" Grid.Row=\"6\"", " Grid.Row=\"7\""),
+            };
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetExpectedReplacementsIgnoresSubsequentNestedGrids()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""2"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+    </Grid>
+</Page>";
+
+            var expected = new List<(string, string)>
+            {
+                (" Grid.Row=\"2\"", " Grid.Row=\"3\""),
+                (" Grid.Row=\"1\"", " Grid.Row=\"2\""),
+            };
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetExpectedReplacementsInNestedGrid()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""2"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition☆ Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+    </Grid>
+</Page>";
+
+            var expected = new List<(string, string)>
+            {
+                (" Grid.Row=\"1\"", " Grid.Row=\"2\""),
+            };
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_Auto()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"Auto\" />", 65);
+
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_Star()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition ☆Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 110);
+
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_InElementName()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <Row☆Definition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 110);
+
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_WorksForAnyPositionInLine()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            ☆<RowDefinition Height=""*"" />☆
+            <RowDefinition Height=""Auto"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 110);
+
+            this.EachPositionBetweenStarsShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_WorksForAnyPositionInLine_FirstLine()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            ☆<RowDefinition Height=""*"" />☆
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 65);
+
+            this.EachPositionBetweenStarsShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_WorksForAnyPositionInLine_LastLine()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            ☆<RowDefinition Height=""*"" />☆
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 155);
+
+            this.EachPositionBetweenStarsShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_AtEndOfDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />☆
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"Auto\" />", 65);
+
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetDefinitionAtCursor_AtStartOfDefinition()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            ☆<RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = ("<RowDefinition Height=\"*\" />", 110);
+
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetGridBoundary_NoOtherGrids()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            ☆<RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />☆
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (14, 259, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetGridBoundary_OtherGridsBeforeAndAfter()
+        {
+            var xaml = @"
+<Page>
+    <StackPanel>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                ☆<RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />☆
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+    </StackPanel>
+</Page>";
+
+            var expected = (323, 596, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetGridBoundary_IgnoreSingleNestedGrid()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            ☆<RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />☆
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""1"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+    </Grid>
+</Page>";
+
+            var expected = (14, 562, new Dictionary<int, int> { { 263, 549 } });
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetGridBoundary_IgnoreMultipleNestedGrids()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            ☆<RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />☆
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""1"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+
+        <Grid Grid.Row=""2"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (14, 856, new Dictionary<int, int> { { 263, 549 }, { 568, 805 } });
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void GetGridBoundary_InNestedGrid()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+        <Grid Grid.Row=""0"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""*"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+
+        <Grid Grid.Row=""1"">
+            <Grid.RowDefinitions>
+                ☆<RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />☆
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+
+        <Grid Grid.Row=""2"">
+            <Grid.RowDefinitions>
+                <RowDefinition Height=""Auto"" />
+                <RowDefinition Height=""*"" />
+            </Grid.RowDefinitions>
+
+            <!-- Content omitted -->
+
+        </Grid>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (516, 802, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        private InsertGridRowDefinitionCommandLogic SetUpLogic(string xaml)
+        {
+            var pos = xaml.IndexOf("☆", StringComparison.Ordinal);
+
+            var vsa = new TestVisualStudioAbstraction
+            {
+                ActiveDocumentText = xaml.Replace("☆", string.Empty),
+                CursorPosition = pos,
+            };
+
+            return new InsertGridRowDefinitionCommandLogic(DefaultTestLogger.Create(), vsa);
+        }
+
+        private void PositionAtStarShouldEnableCommand(string xaml, bool expected)
+        {
+            var logic = this.SetUpLogic(xaml);
+
+            var actual = logic.ShouldEnableCommand();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        private void EachPositionBetweenStarsShouldReturnRowNumber(string xaml, int expected)
+        {
+            var startPos = xaml.IndexOf("☆", StringComparison.Ordinal);
+            var endPos = xaml.LastIndexOf("☆", StringComparison.Ordinal) - 1;
+
+            var positionsTested = 0;
+
+            var plainXaml = xaml.Replace("☆", string.Empty);
+
+            for (var pos = startPos; pos < endPos; pos++)
+            {
+                var vsa = new TestVisualStudioAbstraction
+                {
+                    ActiveDocumentText = plainXaml,
+                    CursorPosition = pos,
+                };
+
+                var logic = new InsertGridRowDefinitionCommandLogic(DefaultTestLogger.Create(), vsa);
+
+                var actual = logic.GetRowNumber();
+
+                Assert.AreEqual(expected, actual, $"Failure at {pos} ({startPos}-{endPos})");
+            }
+
+            this.TestContext.WriteLine($"{positionsTested} different positions tested.");
+        }
+
+        private void PositionAtStarShouldReturnRowNumber(string xaml, int expected)
+        {
+            var logic = this.SetUpLogic(xaml);
+
+            var actual = logic.GetRowNumber();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        private void PositionAtStarShouldReturnExpectedReplacements(string xaml, List<(string, string)> expected)
+        {
+            var logic = this.SetUpLogic(xaml);
+
+            var actual = logic.GetReplacements();
+
+            // Assert isn't able to compare lists of tuples automatically so doing the heavy lifting directly
+            Assert.AreEqual(expected.Count, actual.Count);
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.AreEqual(expected[i].Item1, actual[i].find);
+                Assert.AreEqual(expected[i].Item2, actual[i].replace);
+            }
+        }
+
+        private void PositionAtStarShouldReturnExpectedDefinition(string xaml, (string, int) expected)
+        {
+            var logic = this.SetUpLogic(xaml);
+
+            var actual = logic.GetDefinitionAtCursor();
+
+            Assert.AreEqual(expected.Item1, actual.Item1);
+            Assert.AreEqual(expected.Item2, actual.Item2);
+        }
+
+        private void EachPositionBetweenStarsShouldReturnExpectedDefinition(string xaml, (string, int) expected)
+        {
+            var startPos = xaml.IndexOf("☆", StringComparison.Ordinal);
+            var endPos = xaml.LastIndexOf("☆", StringComparison.Ordinal) - 1;
+
+            var positionsTested = 0;
+
+            var plainXaml = xaml.Replace("☆", string.Empty);
+
+            for (var pos = startPos; pos < endPos; pos++)
+            {
+                var vsa = new TestVisualStudioAbstraction
+                {
+                    ActiveDocumentText = plainXaml,
+                    CursorPosition = pos,
+                };
+
+                var logic = new InsertGridRowDefinitionCommandLogic(DefaultTestLogger.Create(), vsa);
+
+                var actual = logic.GetDefinitionAtCursor();
+
+                Assert.AreEqual(expected.Item1, actual.Item1, $"Failure at {pos} ({startPos}-{endPos})");
+                Assert.AreEqual(expected.Item2, actual.Item2, $"Failure at {pos} ({startPos}-{endPos})");
+                positionsTested += 1;
+            }
+
+            this.TestContext.WriteLine($"{positionsTested} different positions tested.");
+        }
+
+        private void EachPositionBetweenStarsShouldReturnExpectedBoundary(string xaml, (int, int, Dictionary<int, int>) expected)
+        {
+            var startPos = xaml.IndexOf("☆", StringComparison.Ordinal);
+            var endPos = xaml.LastIndexOf("☆", StringComparison.Ordinal) - 1;
+
+            var positionsTested = 0;
+
+            var plainXaml = xaml.Replace("☆", string.Empty);
+
+            for (var pos = startPos; pos < endPos; pos++)
+            {
+                var vsa = new TestVisualStudioAbstraction
+                {
+                    ActiveDocumentText = plainXaml,
+                    CursorPosition = pos,
+                };
+
+                var logic = new InsertGridRowDefinitionCommandLogic(DefaultTestLogger.Create(), vsa);
+
+                var actual = logic.GetGridBoundary();
+
+                Assert.AreEqual(expected.Item1, actual.start, $"Failure at {pos} ({startPos}-{endPos})");
+                Assert.AreEqual(expected.Item2, actual.end, $"Failure at {pos} ({startPos}-{endPos})");
+                Assert.IsNotNull(actual.exclusions, $"Failure at {pos} ({startPos}-{endPos})");
+                Assert.AreEqual(expected.Item3.Count, actual.exclusions.Count, $"Failure at {pos} ({startPos}-{endPos})");
+
+                foreach (var expectedKey in expected.Item3.Keys)
+                {
+                    Assert.IsTrue(actual.exclusions.ContainsKey(expectedKey), $"Failure at {pos} , Key {expectedKey}");
+                    Assert.AreEqual(actual.exclusions[expectedKey], expected.Item3[expectedKey], $"Failure at {pos} , Value for {expectedKey}");
+                }
+
+                positionsTested += 1;
+            }
+
+            this.TestContext.WriteLine($"{positionsTested} different positions tested.");
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Grid/InsertRowDefinitionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Grid/InsertRowDefinitionTests.cs
@@ -715,6 +715,300 @@ namespace RapidXamlToolkit.Tests.Grid
             this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
         }
 
+        [TestMethod]
+        public void HandleNoClosingRowDefinition_GetDefinitionAtCursor()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" /
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (string.Empty, -1);
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinition_GetReplacements()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" /
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, null);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinition_GetGridBoundary()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <☆RowDefinition Height=""Auto☆""
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (-1, -1, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinition_GetRowNumber()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" /
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldReturnRowNumber(xaml, -1);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinition_ShouldEnableCommand()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height=""*"" />
+            <RowDefinition ☆Height=""Auto""
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, false);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinitions_GetDefinitionAtCursor()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefin
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (string.Empty, -1);
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinitions_GetReplacements()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDef
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, null);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinitions_GetGridBoundary()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <☆RowDefinition Height=""Auto"" /☆>
+            <RowDefinition Height=""*"" />
+        </Gri
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            var expected = (-1, -1, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinitions_GetRowNumber()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefi
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldReturnRowNumber(xaml, -1);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingRowDefinitions_ShouldEnableCommand()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDe
+
+        <!-- Content omitted -->
+
+    </Grid>
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, false);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingGrid_GetDefinitionAtCursor()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Gri
+</Page>";
+
+            var expected = (string.Empty, -1);
+            this.PositionAtStarShouldReturnExpectedDefinition(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingGrid_GetReplacements()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Gri
+</Page>";
+
+            this.PositionAtStarShouldReturnExpectedReplacements(xaml, null);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingGrid_GetGridBoundary()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <☆RowDefinition Height=""Auto"" /☆>
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Gri
+</Page>";
+
+            var expected = (-1, -1, new Dictionary<int, int>());
+
+            this.EachPositionBetweenStarsShouldReturnExpectedBoundary(xaml, expected);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingGrid_GetRowNumber()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Gri
+</Page>";
+
+            this.PositionAtStarShouldReturnRowNumber(xaml, -1);
+        }
+
+        [TestMethod]
+        public void HandleNoClosingGrid_ShouldEnableCommand()
+        {
+            var xaml = @"
+<Page>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition ☆Height=""Auto"" />
+            <RowDefinition Height=""*"" />
+        </Grid.RowDefinitions>
+
+        <!-- Content omitted -->
+
+    </Gri
+</Page>";
+
+            this.PositionAtStarShouldEnableCommand(xaml, false);
+        }
+
         private InsertGridRowDefinitionCommandLogic SetUpLogic(string xaml)
         {
             var pos = xaml.IndexOf("☆", StringComparison.Ordinal);
@@ -779,13 +1073,16 @@ namespace RapidXamlToolkit.Tests.Grid
 
             var actual = logic.GetReplacements();
 
-            // Assert isn't able to compare lists of tuples automatically so doing the heavy lifting directly
-            Assert.AreEqual(expected.Count, actual.Count);
-
-            for (int i = 0; i < expected.Count; i++)
+            if (expected != null && actual != null)
             {
-                Assert.AreEqual(expected[i].Item1, actual[i].find);
-                Assert.AreEqual(expected[i].Item2, actual[i].replace);
+                // Assert isn't able to compare lists of tuples automatically so doing the heavy lifting directly
+                Assert.AreEqual(expected.Count, actual.Count);
+
+                for (int i = 0; i < expected.Count; i++)
+                {
+                    Assert.AreEqual(expected[i].Item1, actual[i].find);
+                    Assert.AreEqual(expected[i].Item2, actual[i].replace);
+                }
             }
         }
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Extensions\StringExtensionTests.cs" />
     <Compile Include="Formatting\OutputGenerationTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Grid\InsertRowDefinitionTests.cs" />
     <Compile Include="Options\DefaultConfigurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SetDatacontext\MiscDatacontextLogicTests.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/TestVisualStudioAbstraction.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/TestVisualStudioAbstraction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using RapidXamlToolkit.Commands;
@@ -24,6 +25,10 @@ namespace RapidXamlToolkit.Tests
         public string ActiveDocumentText { get; set; }
 
         public bool DocumentIsCSharp { get; set; } = false;
+
+        public int CursorPosition { get; set; } = -1;
+
+        public int LineNumber { get; set; } = 1;  // Assume that everything is on one line for testing. Bypasses the way VS adds extra char for end of line
 
         public ProjectWrapper GetActiveProject()
         {
@@ -65,6 +70,21 @@ namespace RapidXamlToolkit.Tests
         public bool ActiveDocumentIsCSharp()
         {
             return this.DocumentIsCSharp;
+        }
+
+        public int GetCursorPosition()
+        {
+            return this.CursorPosition;
+        }
+
+        public (int, int) GetCursorPositionAndLineNumber()
+        {
+            return (this.CursorPosition, this.LineNumber);
+        }
+
+        public void ReplaceInActiveDoc(List<(string find, string replace)> replacements, int startIndex, int endIndex, Dictionary<int, int> exclusion)
+        {
+            // NOOP
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/IVisualStudioAbstraction.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/IVisualStudioAbstraction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
@@ -23,5 +24,12 @@ namespace RapidXamlToolkit.Commands
         string GetActiveDocumentText();
 
         bool ActiveDocumentIsCSharp();
+
+        // This should be the selection start if not a single point
+        int GetCursorPosition();
+
+        (int, int) GetCursorPositionAndLineNumber();
+
+        void ReplaceInActiveDoc(List<(string find, string replace)> replacements, int startIndex, int endIndex, Dictionary<int, int> exclusions);
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommand.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.ComponentModel.Design;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using RapidXamlToolkit.Logging;
+using RapidXamlToolkit.Resources;
+using Task = System.Threading.Tasks.Task;
+
+namespace RapidXamlToolkit.Commands
+{
+    internal sealed class InsertGridRowDefinitionCommand : BaseCommand
+    {
+        public const int CommandId = 4133;
+
+        private InsertGridRowDefinitionCommand(AsyncPackage package, OleMenuCommandService commandService, ILogger logger)
+            : base(package, logger)
+        {
+            commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+
+            var menuCommandID = new CommandID(CommandSet, CommandId);
+            var menuItem = new OleMenuCommand(this.Execute, menuCommandID);
+            menuItem.BeforeQueryStatus += this.MenuItem_BeforeQueryStatus;
+            commandService.AddCommand(menuItem);
+        }
+
+        public static InsertGridRowDefinitionCommand Instance
+        {
+            get;
+            private set;
+        }
+
+        public static async Task InitializeAsync(AsyncPackage package, ILogger logger)
+        {
+            // Verify the current thread is the UI thread - the call to AddCommand in the constructor requires the UI thread.
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            OleMenuCommandService commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+            Instance = new InsertGridRowDefinitionCommand(package, commandService, logger);
+        }
+
+        private async void MenuItem_BeforeQueryStatus(object sender, EventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine("MenuItem_BeforeQueryStatus");
+            try
+            {
+                if (sender is OleMenuCommand menuCmd)
+                {
+                    var dte = await Instance.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
+
+                    var logic = new InsertGridRowDefinitionCommandLogic(this.Logger, new VisualStudioAbstraction(dte));
+
+                    var showCommandButton = logic.ShouldEnableCommand();
+
+                    // Changed text isn't shown until subsequent display and so wrong number may be shown
+                    ////if (showCommandButton)
+                    ////{
+                    ////    var rowNumber = logic.GetRowNumber();
+                    ////    menuCmd.Text = $"Insert new row {rowNumber} definition"; // Will need localizing if/when get this working
+                    ////}
+
+                    menuCmd.Visible = menuCmd.Enabled = showCommandButton;
+                }
+            }
+            catch (Exception exc)
+            {
+                this.Logger.RecordException(exc);
+                throw;
+            }
+        }
+
+        private async void Execute(object sender, EventArgs e)
+        {
+            try
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                this.Logger?.RecordFeatureUsage(nameof(InsertGridRowDefinitionCommand));
+
+                var dte = await Instance.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
+                var vs = new VisualStudioAbstraction(dte);
+
+                var logic = new InsertGridRowDefinitionCommandLogic(this.Logger, vs);
+
+                var replacements = logic.GetReplacements();
+                var (start, end, exclusions) = logic.GetGridBoundary();
+                var (newDefinition, newDefPos) = logic.GetDefinitionAtCursor();
+
+                vs.StartSingleUndoOperation(StringRes.Info_UndoContextIndertRowDef);
+                try
+                {
+                    vs.ReplaceInActiveDoc(replacements, start, end, exclusions);
+                    vs.InsertIntoActiveDocumentOnNextLine(newDefinition, newDefPos);
+                }
+                finally
+                {
+                    vs.EndSingleUndoOperation();
+                }
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.RecordException(exc);
+                throw;
+            }
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommandLogic.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using RapidXamlToolkit.Logging;
+
+namespace RapidXamlToolkit.Commands
+{
+    public class InsertGridRowDefinitionCommandLogic
+    {
+        private const string RowDefOpening = "<RowDefinition";
+
+        private ILogger logger;
+        private IVisualStudioAbstraction vs;
+
+        public InsertGridRowDefinitionCommandLogic(ILogger logger, IVisualStudioAbstraction visualStudioAbstraction)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.vs = visualStudioAbstraction ?? throw new ArgumentNullException(nameof(visualStudioAbstraction));
+        }
+
+        public bool ShouldEnableCommand()
+        {
+            var activeDocText = this.vs.GetActiveDocumentText();
+            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+            // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+            // Add XAML Lenght to allwo for cursor being in this text
+            var searchPoint = cursorIndex + lineNo - 1 + RowDefOpening.Length;
+
+            var docOfInterest = activeDocText.Substring(0, searchPoint);
+
+            var closingDefPosition = docOfInterest.LastIndexOf("</Grid.RowDefinitions>");
+            var lastDefPosition = docOfInterest.LastIndexOf(RowDefOpening);
+
+            return lastDefPosition > closingDefPosition;
+        }
+
+        public int GetRowNumber()
+        {
+            var activeDocText = this.vs.GetActiveDocumentText();
+            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+            var docOfInterest = activeDocText.Substring(0, cursorIndex + lineNo - 1 + RowDefOpening.Length); // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+
+            var closingDefPosition = docOfInterest.LastIndexOf("</Grid.RowDefinitions>");
+
+            if (closingDefPosition > 0)
+            {
+                docOfInterest = docOfInterest.Substring(closingDefPosition);
+            }
+
+            var occurrences = docOfInterest.OccurrenceCount(RowDefOpening);
+
+            return occurrences - 1;  // Remove one to account for rows being zero indexed
+        }
+
+        public int GetTotalRowDefinitions()
+        {
+            var activeDocText = this.vs.GetActiveDocumentText();
+            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+            cursorIndex += lineNo - 1; // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+
+            var closingDefPosition = cursorIndex + activeDocText.Substring(cursorIndex).IndexOf("</Grid.RowDefinitions>");
+            var openingDefPosition = activeDocText.Substring(0, cursorIndex).LastIndexOf("<Grid.RowDefinitions>");
+
+            var docOfInterest = activeDocText.Substring(openingDefPosition, closingDefPosition - openingDefPosition);
+
+            var occurrences = docOfInterest.OccurrenceCount(RowDefOpening);
+
+            return occurrences;
+        }
+
+        public (int start, int end, Dictionary<int, int> exclusions) GetGridBoundary()
+        {
+            var activeDocText = this.vs.GetActiveDocumentText();
+            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+            cursorIndex += lineNo - 1; // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+
+            const string gridOpenSpace = "<Grid ";
+            const string gridOpenComplete = "<Grid>";
+            const string gridClose = "</Grid>";
+
+            var openingGridPos = activeDocText.Substring(0, cursorIndex + lineNo - 1).LastIndexOf(gridOpenComplete, gridOpenSpace);
+
+            var closingGridPos = openingGridPos + activeDocText.Substring(openingGridPos).IndexOf(gridClose);
+
+            var exclusions = new Dictionary<int, int>();
+
+            var nextOpening = activeDocText.Substring(cursorIndex).FirstIndexOf(gridOpenComplete, gridOpenSpace);
+
+            if (nextOpening > -1)
+            {
+                nextOpening += cursorIndex;
+            }
+
+            while (nextOpening > -1 && nextOpening < closingGridPos)
+            {
+                exclusions.Add(nextOpening, closingGridPos);
+
+                var searchFrom = closingGridPos + 1;
+
+                closingGridPos = searchFrom + activeDocText.Substring(searchFrom).IndexOf(gridClose);
+
+                searchFrom = nextOpening + 1;
+
+                nextOpening = activeDocText.Substring(searchFrom).FirstIndexOf(gridOpenComplete, gridOpenSpace);
+
+                if (nextOpening > -1)
+                {
+                    nextOpening += searchFrom;
+                }
+            }
+
+            return (openingGridPos, closingGridPos, exclusions);
+        }
+
+        public List<(string find, string replace)> GetReplacements()
+        {
+            var rowNumber = this.GetRowNumber();
+            var rowDefs = this.GetTotalRowDefinitions();
+
+            var result = new List<(string, string)>();
+
+            // subtract 1 from total rows to allow for zero indexing
+            for (int i = rowDefs - 1; i >= rowNumber; i--)
+            {
+                result.Add(($" Grid.Row=\"{i}\"", $" Grid.Row=\"{i + 1}\""));
+            }
+
+            return result;
+        }
+
+        public (string definition, int insertPos) GetDefinitionAtCursor()
+        {
+            var activeDocText = this.vs.GetActiveDocumentText();
+            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+            cursorIndex += lineNo - 1;  // Account for extra char in line feed in VS display
+
+            var openingPos = activeDocText.Substring(0, cursorIndex + RowDefOpening.Length).LastIndexOf(RowDefOpening);  // Move on row def length to allow for cursor being anywhere in it
+            var length = activeDocText.Substring(openingPos).IndexOf("/>") + 2;  // Add 2 for length of search string
+
+            return (activeDocText.Substring(openingPos, length), openingPos);
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/InsertGridRowDefinitionCommandLogic.cs
@@ -23,37 +23,54 @@ namespace RapidXamlToolkit.Commands
         public bool ShouldEnableCommand()
         {
             var activeDocText = this.vs.GetActiveDocumentText();
-            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            // Add lineNo to account for VS adding extra char to line feed & -1 for current line
-            // Add XAML Lenght to allwo for cursor being in this text
-            var searchPoint = cursorIndex + lineNo - 1 + RowDefOpening.Length;
+            if (activeDocText.IsValidXml())
+            {
+                var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            var docOfInterest = activeDocText.Substring(0, searchPoint);
+                // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+                // Add XAML Lenght to allow for cursor being in this text
+                var searchPoint = cursorIndex + lineNo - 1 + RowDefOpening.Length;
 
-            var closingDefPosition = docOfInterest.LastIndexOf("</Grid.RowDefinitions>");
-            var lastDefPosition = docOfInterest.LastIndexOf(RowDefOpening);
+                var docOfInterest = activeDocText.Substring(0, searchPoint);
 
-            return lastDefPosition > closingDefPosition;
+                var closingDefsPosition = searchPoint + activeDocText.Substring(searchPoint).IndexOf("</Grid.RowDefinitions>");
+                var closingGridPosition = searchPoint + activeDocText.Substring(searchPoint).IndexOf("</Grid>");
+                var lastDefPosition = docOfInterest.LastIndexOf(RowDefOpening);
+
+                return closingDefsPosition > -1 && lastDefPosition > -1 && closingGridPosition > -1 && lastDefPosition < searchPoint && searchPoint < closingDefsPosition && closingDefsPosition < closingGridPosition;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public int GetRowNumber()
         {
             var activeDocText = this.vs.GetActiveDocumentText();
-            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            var docOfInterest = activeDocText.Substring(0, cursorIndex + lineNo - 1 + RowDefOpening.Length); // Add lineNo to account for VS adding extra char to line feed & -1 for current line
-
-            var closingDefPosition = docOfInterest.LastIndexOf("</Grid.RowDefinitions>");
-
-            if (closingDefPosition > 0)
+            if (activeDocText.IsValidXml())
             {
-                docOfInterest = docOfInterest.Substring(closingDefPosition);
+                var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
+
+                var docOfInterest = activeDocText.Substring(0, cursorIndex + lineNo - 1 + RowDefOpening.Length); // Add lineNo to account for VS adding extra char to line feed & -1 for current line
+
+                var closingDefPosition = docOfInterest.LastIndexOf("</Grid.RowDefinitions>");
+
+                if (closingDefPosition > 0)
+                {
+                    docOfInterest = docOfInterest.Substring(closingDefPosition);
+                }
+
+                var occurrences = docOfInterest.OccurrenceCount(RowDefOpening);
+
+                return occurrences - 1; // Remove one to account for rows being zero indexed
             }
-
-            var occurrences = docOfInterest.OccurrenceCount(RowDefOpening);
-
-            return occurrences - 1;  // Remove one to account for rows being zero indexed
+            else
+            {
+                return -1;
+            }
         }
 
         public int GetTotalRowDefinitions()
@@ -76,75 +93,100 @@ namespace RapidXamlToolkit.Commands
         public (int start, int end, Dictionary<int, int> exclusions) GetGridBoundary()
         {
             var activeDocText = this.vs.GetActiveDocumentText();
-            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            cursorIndex += lineNo - 1; // Add lineNo to account for VS adding extra char to line feed & -1 for current line
-
-            const string gridOpenSpace = "<Grid ";
-            const string gridOpenComplete = "<Grid>";
-            const string gridClose = "</Grid>";
-
-            var openingGridPos = activeDocText.Substring(0, cursorIndex + lineNo - 1).LastIndexOf(gridOpenComplete, gridOpenSpace);
-
-            var closingGridPos = openingGridPos + activeDocText.Substring(openingGridPos).IndexOf(gridClose);
-
-            var exclusions = new Dictionary<int, int>();
-
-            var nextOpening = activeDocText.Substring(cursorIndex).FirstIndexOf(gridOpenComplete, gridOpenSpace);
-
-            if (nextOpening > -1)
+            if (activeDocText.IsValidXml())
             {
-                nextOpening += cursorIndex;
-            }
+                var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            while (nextOpening > -1 && nextOpening < closingGridPos)
-            {
-                exclusions.Add(nextOpening, closingGridPos);
+                cursorIndex += lineNo - 1; // Add lineNo to account for VS adding extra char to line feed & -1 for current line
 
-                var searchFrom = closingGridPos + 1;
+                const string gridOpenSpace = "<Grid ";
+                const string gridOpenComplete = "<Grid>";
+                const string gridClose = "</Grid>";
 
-                closingGridPos = searchFrom + activeDocText.Substring(searchFrom).IndexOf(gridClose);
+                var openingGridPos = activeDocText.Substring(0, cursorIndex + lineNo - 1).LastIndexOf(gridOpenComplete, gridOpenSpace);
 
-                searchFrom = nextOpening + 1;
+                var closingGridPos = openingGridPos + activeDocText.Substring(openingGridPos).IndexOf(gridClose);
 
-                nextOpening = activeDocText.Substring(searchFrom).FirstIndexOf(gridOpenComplete, gridOpenSpace);
+                var exclusions = new Dictionary<int, int>();
+
+                var nextOpening = activeDocText.Substring(cursorIndex).FirstIndexOf(gridOpenComplete, gridOpenSpace);
 
                 if (nextOpening > -1)
                 {
-                    nextOpening += searchFrom;
+                    nextOpening += cursorIndex;
                 }
-            }
 
-            return (openingGridPos, closingGridPos, exclusions);
+                while (nextOpening > -1 && nextOpening < closingGridPos)
+                {
+                    exclusions.Add(nextOpening, closingGridPos);
+
+                    var searchFrom = closingGridPos + 1;
+
+                    closingGridPos = searchFrom + activeDocText.Substring(searchFrom).IndexOf(gridClose);
+
+                    searchFrom = nextOpening + 1;
+
+                    nextOpening = activeDocText.Substring(searchFrom).FirstIndexOf(gridOpenComplete, gridOpenSpace);
+
+                    if (nextOpening > -1)
+                    {
+                        nextOpening += searchFrom;
+                    }
+                }
+
+                return (openingGridPos, closingGridPos, exclusions);
+            }
+            else
+            {
+                return (-1, -1, new Dictionary<int, int>());
+            }
         }
 
         public List<(string find, string replace)> GetReplacements()
         {
             var rowNumber = this.GetRowNumber();
-            var rowDefs = this.GetTotalRowDefinitions();
 
-            var result = new List<(string, string)>();
-
-            // subtract 1 from total rows to allow for zero indexing
-            for (int i = rowDefs - 1; i >= rowNumber; i--)
+            if (rowNumber > -1)
             {
-                result.Add(($" Grid.Row=\"{i}\"", $" Grid.Row=\"{i + 1}\""));
-            }
+                var rowDefs = this.GetTotalRowDefinitions();
 
-            return result;
+                var result = new List<(string, string)>();
+
+                // subtract 1 from total rows to allow for zero indexing
+                for (int i = rowDefs - 1; i >= rowNumber; i--)
+                {
+                    result.Add(($" Grid.Row=\"{i}\"", $" Grid.Row=\"{i + 1}\""));
+                }
+
+                return result;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public (string definition, int insertPos) GetDefinitionAtCursor()
         {
             var activeDocText = this.vs.GetActiveDocumentText();
-            var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            cursorIndex += lineNo - 1;  // Account for extra char in line feed in VS display
+            if (activeDocText.IsValidXml())
+            {
+                var (cursorIndex, lineNo) = this.vs.GetCursorPositionAndLineNumber();
 
-            var openingPos = activeDocText.Substring(0, cursorIndex + RowDefOpening.Length).LastIndexOf(RowDefOpening);  // Move on row def length to allow for cursor being anywhere in it
-            var length = activeDocText.Substring(openingPos).IndexOf("/>") + 2;  // Add 2 for length of search string
+                cursorIndex += lineNo - 1; // Account for extra char in line feed in VS display
 
-            return (activeDocText.Substring(openingPos, length), openingPos);
+                var openingPos = activeDocText.Substring(0, cursorIndex + RowDefOpening.Length)
+                    .LastIndexOf(RowDefOpening); // Move on row def length to allow for cursor being anywhere in it
+                var length = activeDocText.Substring(openingPos).IndexOf("/>") + 2; // Add 2 for length of search string
+
+                return (activeDocText.Substring(openingPos, length), openingPos);
+            }
+            else
+            {
+                return (string.Empty, -1);
+            }
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs
@@ -55,6 +55,7 @@ namespace RapidXamlToolkit
                 await SendToToolboxCommand.InitializeAsync(this, Logger);
                 await OpenOptionsCommand.InitializeAsync(this, Logger);
                 await SetDatacontextCommand.InitializeAsync(this, Logger);
+                await InsertGridRowDefinitionCommand.InitializeAsync(this, Logger);
             }
             catch (Exception exc)
             {

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs-CZ.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs-CZ.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Nastavit kontext dat</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Datenkontext festlegen</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.en-US.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.en-US.vsct
@@ -119,6 +119,15 @@
           <ButtonText>Set Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <Bitmaps>
@@ -201,6 +210,10 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
 
   <Symbols>
@@ -224,6 +237,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
 
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Establecer contexto de datos</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Définir Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.it-IT.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.it-IT.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Imposta Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ja-JP.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ja-JP.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Datacontext を設定</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ko-KR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ko-KR.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Datacontext 설정</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pl-PL.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pl-PL.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Ustaw element Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Definir Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Задать контекст данных</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
@@ -111,6 +111,15 @@
           <ButtonText>Veri Bağlamını Ayarla</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
@@ -111,6 +111,15 @@
           <ButtonText>设置数据上下文</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-TW.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-TW.vsct
@@ -111,6 +111,15 @@
           <ButtonText>設定 Datacontext</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0100" type="Button">
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <!--<CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>TextChangesButton</CommandFlag>-->
+        <Strings>
+          <ButtonText>Insert Row Definition</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others:
@@ -173,6 +182,9 @@
     <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="OpenOptionsCommandId" priority="0x0300">
       <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
     </CommandPlacement>
+    <CommandPlacement guid="guidRapidXamlPackageCmdSet" id="InsertGridRowDefinitionCommandId" priority="0x0200">
+      <Parent guid="guidRapidXamlPackageCmdSet" id="XamlContextMenuGroup" />
+    </CommandPlacement>
   </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
@@ -193,6 +205,7 @@
       <IDSymbol name="CreateViewCommandId" value="4130" />
       <IDSymbol name="OpenOptionsCommandId" value="4131" />
       <IDSymbol name="SetDatacontextCommandId" value="4132" />
+      <IDSymbol name="InsertGridRowDefinitionCommandId" value="4133" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{092daafa-627f-4f53-a712-4e3e5fa72e0d}">
       <IDSymbol name="bmpCopyAsXaml" value="1" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -73,6 +73,8 @@
     <Compile Include="Commands\BaseCommand.cs" />
     <Compile Include="Commands\CreateViewCommandLogic.cs" />
     <Compile Include="Commands\IFileSystemAbstraction.cs" />
+    <Compile Include="Commands\InsertGridRowDefinitionCommand.cs" />
+    <Compile Include="Commands\InsertGridRowDefinitionCommandLogic.cs" />
     <Compile Include="Commands\IVisualStudioAbstraction.cs" />
     <Compile Include="Commands\OpenOptionsCommand.cs" />
     <Compile Include="Commands\ProjectWrapper.cs" />
@@ -603,6 +605,7 @@
     </VSCTCompile>
     <VSCTCompile Include="RapidXamlPackage.en-US.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>
+      <SubType>Designer</SubType>
     </VSCTCompile>
     <VSCTCompile Include="RapidXamlPackage.es-ES.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -583,6 +583,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to insert RowDefinition (Invalid XAML).
+        /// </summary>
+        public static string Info_UnableToInsertRowDefinitionInvalidXaml {
+            get {
+                return ResourceManager.GetString("Info_UnableToInsertRowDefinitionInvalidXaml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Insert RowDefinition.
         /// </summary>
         public static string Info_UndoContextIndertRowDef {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -583,6 +583,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Insert RowDefinition.
+        /// </summary>
+        public static string Info_UndoContextIndertRowDef {
+            get {
+                return ResourceManager.GetString("Info_UndoContextIndertRowDef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Using class grouping of &apos;{0}&apos;..
         /// </summary>
         public static string Info_UsingClassGrouping {
@@ -1443,6 +1452,15 @@ namespace RapidXamlToolkit.Resources {
         public static string VSCT__SetDatacontextCommandId {
             get {
                 return ResourceManager.GetString("VSCT__SetDatacontextCommandId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Insert Row Definition.
+        /// </summary>
+        public static string VSCT_InsertGridRowDefinitionCommandId {
+            get {
+                return ResourceManager.GetString("VSCT_InsertGridRowDefinitionCommandId", resourceCulture);
             }
         }
         

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -598,4 +598,11 @@
     <value>Rapid XAML Toolkit</value>
     <comment>Name used in vsixlangpack</comment>
   </data>
+  <data name="Info_UndoContextIndertRowDef" xml:space="preserve">
+    <value>Insert RowDefinition</value>
+  </data>
+  <data name="VSCT_InsertGridRowDefinitionCommandId" xml:space="preserve">
+    <value>Insert Row Definition</value>
+    <comment>Command button text for when inserting a new RowDefinition</comment>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -605,4 +605,7 @@
     <value>Insert Row Definition</value>
     <comment>Command button text for when inserting a new RowDefinition</comment>
   </data>
+  <data name="Info_UnableToInsertRowDefinitionInvalidXaml" xml:space="preserve">
+    <value>Unable to insert RowDefinition (Invalid XAML)</value>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -598,4 +598,11 @@
     <value>Rapid XAML Toolkit</value>
     <comment>Name used in vsixlangpack</comment>
   </data>
+  <data name="Info_UndoContextIndertRowDef" xml:space="preserve">
+    <value>Insert RowDefinition</value>
+  </data>
+  <data name="VSCT_InsertGridRowDefinitionCommandId" xml:space="preserve">
+    <value>Insert Row Definition</value>
+    <comment>Command button text for when inserting a new RowDefinition</comment>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -605,4 +605,7 @@
     <value>Insert Row Definition</value>
     <comment>Command button text for when inserting a new RowDefinition</comment>
   </data>
+  <data name="Info_UnableToInsertRowDefinitionInvalidXaml" xml:space="preserve">
+    <value>Unable to insert RowDefinition (Invalid XAML)</value>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -305,6 +305,22 @@ namespace RapidXamlToolkit
             return true;
         }
 
+        public static bool IsValidXml(this string source)
+        {
+            try
+            {
+                var xdoc = new XmlDocument();
+                xdoc.LoadXml(source);
+
+                // If loaded OK assume it's valid
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         private static List<string> GetPlaceholders(this string source)
         {
             var plchldrRgx = new Regex("([$$][\\w]+[$$])");

--- a/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -201,6 +201,49 @@ namespace RapidXamlToolkit
             return System.Text.RegularExpressions.Regex.Replace(source, "([a-z](?=[A-Z]|[0-9])|[A-Z](?=[A-Z][a-z]|[0-9])|[0-9](?=[^0-9]))", "$1 ");
         }
 
+        public static int OccurrenceCount(this string source, string substring)
+        {
+            return source.Split(new[] { substring }, StringSplitOptions.None).Length - 1;
+        }
+
+        public static int FirstIndexOf(this string source, params string[] values)
+        {
+            var valuePostions = new Dictionary<string, int>();
+
+            foreach (var value in values)
+            {
+                valuePostions.Add(value, source.IndexOf(value));
+            }
+
+            if (valuePostions.Any(v => v.Value > -1))
+            {
+                var result = valuePostions.Select(v => v.Value).Where(v => v > -1).OrderBy(v => v).FirstOrDefault();
+
+                return result;
+            }
+
+            return -1;
+        }
+
+        public static int LastIndexOf(this string source, params string[] values)
+        {
+            var valuePostions = new Dictionary<string, int>();
+
+            foreach (var value in values)
+            {
+                valuePostions.Add(value, source.LastIndexOf(value));
+            }
+
+            if (valuePostions.Any(v => v.Value > -1))
+            {
+                var result = valuePostions.Select(v => v.Value).Where(v => v > -1).OrderByDescending(v => v).FirstOrDefault();
+
+                return result;
+            }
+
+            return -1;
+        }
+
         public static bool IsValidXamlOutput(this string source)
         {
             const string validText = "ValidText";


### PR DESCRIPTION
This PR relates to Issue #83

**Description**  
Insert the `RowDefinition` and move subsequent row numbers accordingly so can add new items at the newly added row


