### PR TITLE
Format generated XAML

### DIFF
--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpArrayTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpArrayTests.cs
@@ -62,8 +62,7 @@ namespace tests
                 Name = "Class1",
                 Output = @"<Bool />
 <BoolBrackets />
-<ArrayBool />
-",
+<ArrayBool />",
                 OutputType = AnalyzerOutputType.Class,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpClassTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpClassTests.cs
@@ -35,11 +35,12 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" />"
-         + Environment.NewLine + "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\"></ItemsControl>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <ItemsControl ItemsSource=\"{x:Bind Property6}\">"
+         + Environment.NewLine + "    </ItemsControl>"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -69,7 +70,7 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -112,7 +113,7 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel Orientation=\"Horizontal\">"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -157,9 +158,9 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
-                                 + Environment.NewLine + "</Grid>";
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
             {
@@ -203,12 +204,12 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -252,10 +253,10 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -299,14 +300,14 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -351,16 +352,16 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -562,11 +563,11 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -612,10 +613,10 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -666,11 +667,11 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDesc\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDesc\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -721,11 +722,17 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -776,23 +783,23 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" Grid.Row=\"0\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "</Grid>"
+         + Environment.NewLine + "    <Grid>"
+         + Environment.NewLine + "        <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "            <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "            <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "        </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <Grid.RowDefinitions>"
+         + Environment.NewLine + "            <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "            <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "            <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "        </Grid.RowDefinitions>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" Grid.Row=\"0\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    </Grid>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -823,9 +830,9 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -861,9 +868,9 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -908,10 +915,10 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind SuperBaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind SuperBaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -942,8 +949,8 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -989,15 +996,21 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_Length\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_LongLength\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_Rank\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_SyncRoot\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsReadOnly\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsFixedSize\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsSynchronized\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_Length\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_LongLength\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_Rank\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_SyncRoot\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsReadOnly\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsFixedSize\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsSynchronized\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1041,10 +1054,16 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1095,11 +1114,17 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_SomeProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_SomeProperty\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1138,7 +1163,7 @@ namespace tests
             {
                 Name = "Class1",
                 Output = @"<form>
-<Dynamic Name=""SomeProperty"" />
+    <Dynamic Name=""SomeProperty"" />
 </form>",
                 OutputType = AnalyzerOutputType.Class,
             };
@@ -1174,9 +1199,9 @@ namespace tests
             {
                 Name = "Class1",
                 Output = @"<form>
-<Dyno>
-<DymnProp Value="""" />
-</Dyno>
+    <Dyno>
+        <DymnProp Value="""" />
+    </Dyno>
 </form>",
                 OutputType = AnalyzerOutputType.Class,
             };
@@ -1234,12 +1259,12 @@ public class Clas*s1
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1297,12 +1322,12 @@ namespace tests
             // Note that using $repint$ on its own in a row (i.e. not after an $incint$) may or may not produce the same output as on the previous line.
             // This is deliberate. $repint$ is not intended to be used on its own.
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" somethingElse=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"0\" somethingElse=\"0\" />"
-         + Environment.NewLine + "<Int Text=\"Property3\" Grid.Row=\"0\" somethingElse=\"0\" anotherThing=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property4\" Grid.Row=\"1\" somethingElse=\"1\" />"
-         + Environment.NewLine + "<Int Text=\"Property5\" Grid.Row=\"1\" somethingElse=\"1\" anotherThing=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property6\" Grid.Row=\"2\" somethingElse=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" somethingElse=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"0\" somethingElse=\"0\" />"
+         + Environment.NewLine + "    <Int Text=\"Property3\" Grid.Row=\"0\" somethingElse=\"0\" anotherThing=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property4\" Grid.Row=\"1\" somethingElse=\"1\" />"
+         + Environment.NewLine + "    <Int Text=\"Property5\" Grid.Row=\"1\" somethingElse=\"1\" anotherThing=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property6\" Grid.Row=\"2\" somethingElse=\"2\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1332,8 +1357,8 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -1365,9 +1390,9 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -1419,11 +1444,11 @@ namespace tests
 }";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1446,8 +1471,8 @@ namespace tests
         private void FindSinglePropertyInClass(string code)
         {
             var expectedOutput = "<StackPanel>"
-                                 + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {
@@ -1462,8 +1487,8 @@ namespace tests
         private void FindNoPropertiesInClass(string code)
         {
             var expectedOutput = "<StackPanel>"
-                                 + Environment.NewLine + "<!-- No accessible properties when copying as XAML -->"
-                                 + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <!-- No accessible properties when copying as XAML -->"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpNullableTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpNullableTests.cs
@@ -73,8 +73,7 @@ namespace tests
                 Output = @"<Bool />
 <BoolQ />
 <NullBool />
-<NullBool />
-",
+<NullBool />",
                 OutputType = AnalyzerOutputType.Class,
             };
 
@@ -171,13 +170,13 @@ namespace tests
                 Type = "List<bool?>",
                 NameContains = string.Empty,
                 IfReadOnly = false,
-                Output = "<LB? />",
+                Output = "<LBnull />",
             });
 
             var expected = new AnalyzerOutput
             {
                 Name = "MyListOfNullables",
-                Output = @"<LB? />",
+                Output = @"<LBnull />",
                 OutputType = AnalyzerOutputType.Property,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpPropertiesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpPropertiesTests.cs
@@ -255,7 +255,7 @@ namespace tests
             {
                 Name = "SomeList",
                 Output = @"<Dyno>
-<DymnProp Value="""" />
+    <DymnProp Value="""" />
 </Dyno>",
                 OutputType = AnalyzerOutputType.Property,
             };
@@ -280,7 +280,8 @@ namespace tests
             var expected = new AnalyzerOutput
             {
                 Name = "MyListProperty",
-                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\"></ItemsControl>",
+                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\">" + Environment.NewLine +
+                         "</ItemsControl>",
                 OutputType = AnalyzerOutputType.Property,
             };
 
@@ -588,9 +589,9 @@ namespace tests
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderDescription\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -643,8 +644,8 @@ namespace tests
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -688,7 +689,7 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -740,9 +741,9 @@ namespace tests
 }";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -801,9 +802,9 @@ namespace tests
 }";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -859,9 +860,9 @@ namespace tests
 }";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -914,7 +915,7 @@ namespace tests
 
             var expectedOutput = "<RadioButton Content=\"Active\" GroupName=\"OrderStatus\" />" + Environment.NewLine +
                                  "<RadioButton Content=\"OnHold\" GroupName=\"OrderStatus\" />" + Environment.NewLine +
-                                 "<RadioButton Content=\"Closed\" GroupName=\"OrderStatus\" />" + Environment.NewLine;
+                                 "<RadioButton Content=\"Closed\" GroupName=\"OrderStatus\" />";
 
             var expected = new AnalyzerOutput
             {
@@ -1036,9 +1037,9 @@ namespace tests
 }";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>On Hold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>On Hold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpSelectionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpSelectionTests.cs
@@ -33,13 +33,14 @@ namespace tests
 }";
 
             var expectedOutput = "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property2\" />"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property3\" />"
-                                 + Environment.NewLine + "<TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\"></ItemsControl>"
-                                 + Environment.NewLine + "<TextBox Text=\"{x:Bind Property7, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "<TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />";
+         + Environment.NewLine + "<TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "<TextBlock Text=\"Property3\" />"
+         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
+         + Environment.NewLine + "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
+         + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\">"
+         + Environment.NewLine + "</ItemsControl>"
+         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property7, Mode=TwoWay}\" />"
+         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />";
 
             var expected = new AnalyzerOutput
             {
@@ -90,9 +91,9 @@ namespace tests
 }";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -354,9 +355,9 @@ namespace tests
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderDescription\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -427,7 +428,7 @@ namespace tests
             {
                 Name = "SomeList",
                 Output = @"<Dyno>
-<DymnProp Value="""" />
+    <DymnProp Value="""" />
 </Dyno>",
                 OutputType = AnalyzerOutputType.Selection,
             };

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpStructsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpStructsTests.cs
@@ -25,8 +25,8 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -124,8 +124,7 @@ namespace tests
             {
                 Name = "MyListProperty",
                 Output = @"<MyProperty1 />
-<MyProperty2 />
-",
+<MyProperty2 />",
                 OutputType = AnalyzerOutputType.Property,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicArrayTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicArrayTests.cs
@@ -58,8 +58,7 @@ End Namespace";
                 Name = "Class1",
                 Output = @"<Bool />
 <Array />
-<ArrayBool />
-",
+<ArrayBool />",
                 OutputType = AnalyzerOutputType.Class,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicClassTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicClassTests.cs
@@ -38,12 +38,13 @@ Public Class Class1
 End Class";
 
             var expectedOutput = "<StackPanel>"
-                + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-                + Environment.NewLine + "<TextBlock Text=\"Property2\" />"
-                + Environment.NewLine + "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
-                + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\"></ItemsControl>"
-                + Environment.NewLine + "<TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />"
-                + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <ItemsControl ItemsSource=\"{x:Bind Property6}\">"
+         + Environment.NewLine + "    </ItemsControl>"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {
@@ -75,7 +76,7 @@ Public Class Class1
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -115,8 +116,8 @@ Public Class Class100 *
 End Class";
 
             var expectedOutput = "<StackPanel Orientation=\"Horizontal\">"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property1\" />"
-                                 + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" />"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {
@@ -156,9 +157,9 @@ Public Class Class100*
 End Class";
 
             var expectedOutput = "<Grid>"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-                                 + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
-                                 + Environment.NewLine + "</Grid>";
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
             {
@@ -198,12 +199,12 @@ Public Class Class100 *
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -244,16 +245,16 @@ Public Class Class100 *
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -293,10 +294,10 @@ Public Class Class100 *
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -336,14 +337,14 @@ Public Class Class100 *
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -501,10 +502,10 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -546,10 +547,10 @@ Pu*blic Class Class1
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -596,11 +597,11 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -646,10 +647,16 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -695,23 +702,23 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<Grid>"
-         + Environment.NewLine + "<Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<ColumnDefinition Width=\"Auto\" />"
-         + Environment.NewLine + "<ColumnDefinition Width=\"*\" />"
-         + Environment.NewLine + "</Grid.ColumnDefinitions>"
-         + Environment.NewLine + "<Grid.RowDefinitions>"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"Auto\" />"
-         + Environment.NewLine + "<RowDefinition Height=\"*\" />"
-         + Environment.NewLine + "</Grid.RowDefinitions>"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderId\" Grid.Row=\"0\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderId\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "</Grid>"
+         + Environment.NewLine + "    <Grid>"
+         + Environment.NewLine + "        <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "            <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "            <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "        </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <Grid.RowDefinitions>"
+         + Environment.NewLine + "            <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "            <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "            <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "        </Grid.RowDefinitions>"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderId\" Grid.Row=\"0\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderId\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderPlacedDateTime\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"FB_OrderDescription\" Grid.Row=\"2\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    </Grid>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -772,12 +779,12 @@ Public Class Clas*s1
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_SomeProperty\" Grid.Row=\"0\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_AnotherProperty\" Grid.Row=\"1\" Grid.Column=\"1\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -806,9 +813,9 @@ Public Class BaseClass
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -839,9 +846,9 @@ Public Class BaseClass
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -879,10 +886,10 @@ Public Class SuperBaseClass
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind SuperBaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind SuperBaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -910,8 +917,8 @@ Public Class Class2
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -952,15 +959,21 @@ Pu*blic Class Class1
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_Length\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_LongLength\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_Rank\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_SyncRoot\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsReadOnly\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsFixedSize\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_IsSynchronized\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_Length\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_LongLength\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_Rank\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_SyncRoot\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsReadOnly\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsFixedSize\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_IsSynchronized\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1000,10 +1013,16 @@ Pu*blic Class Class1
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1050,11 +1069,17 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_TestProperty\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_BaseTestProperty\" />"
-         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_TestProperty\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_BaseTestProperty\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1091,7 +1116,7 @@ End Namespace";
             {
                 Name = "Class1",
                 Output = @"<form>
-<Dynamic Name=""SomeProperty"" />
+    <Dynamic Name=""SomeProperty"" />
 </form>",
                 OutputType = AnalyzerOutputType.Class,
             };
@@ -1125,9 +1150,9 @@ End Namespace";
             {
                 Name = "Class1",
                 Output = @"<form>
-<Dyno>
-<DymnProp Value="""" />
-</Dyno>
+    <Dyno>
+        <DymnProp Value="""" />
+    </Dyno>
 </form>",
                 OutputType = AnalyzerOutputType.Class,
             };
@@ -1178,12 +1203,12 @@ End Namespace";
             // Note that using $repint$ on its own in a row (i.e. not after an $incint$) may or may not produce the same output as on the previous line.
             // This is deliberate. $repint$ is not intended to be used on its own.
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<TextBlock Text=\"Property1\" Grid.Row=\"0\" somethingElse=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property2\" Grid.Row=\"0\" somethingElse=\"0\" />"
-         + Environment.NewLine + "<Int Text=\"Property3\" Grid.Row=\"0\" somethingElse=\"0\" anotherThing=\"0\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property4\" Grid.Row=\"1\" somethingElse=\"1\" />"
-         + Environment.NewLine + "<Int Text=\"Property5\" Grid.Row=\"1\" somethingElse=\"1\" anotherThing=\"1\" />"
-         + Environment.NewLine + "<TextBlock Text=\"Property6\" Grid.Row=\"2\" somethingElse=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" Grid.Row=\"0\" somethingElse=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" Grid.Row=\"0\" somethingElse=\"0\" />"
+         + Environment.NewLine + "    <Int Text=\"Property3\" Grid.Row=\"0\" somethingElse=\"0\" anotherThing=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property4\" Grid.Row=\"1\" somethingElse=\"1\" />"
+         + Environment.NewLine + "    <Int Text=\"Property5\" Grid.Row=\"1\" somethingElse=\"1\" anotherThing=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property6\" Grid.Row=\"2\" somethingElse=\"2\" />"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1209,8 +1234,8 @@ Public Class Class1*
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -1240,9 +1265,9 @@ Public Class BaseClass
 End Class";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind BaseProperty, Mode=TwoWay}\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -1289,11 +1314,11 @@ Public Class Order
 End Class";
 
             var expectedOutput = "<Grid>"
-         + Environment.NewLine + "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
-         + Environment.NewLine + "</StackPanel>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    </StackPanel>"
          + Environment.NewLine + "</Grid>";
 
             var expected = new AnalyzerOutput
@@ -1309,8 +1334,8 @@ End Class";
         private void FindNoPropertiesInClass(string code)
         {
             var expectedOutput = "<StackPanel>"
-                                 + Environment.NewLine + "<!-- No accessible properties when copying as XAML -->"
-                                 + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <!-- No accessible properties when copying as XAML -->"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {
@@ -1325,8 +1350,8 @@ End Class";
         private void FindSinglePropertyInClass(string code)
         {
             var expectedOutput = "<StackPanel>"
-                                 + Environment.NewLine + "<TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
-                                 + Environment.NewLine + "</StackPanel>";
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Property1, Mode=TwoWay}\" />"
+         + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
             {

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicNullableTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicNullableTests.cs
@@ -69,8 +69,7 @@ End Namespace";
                 Output = @"<Bool />
 <BoolQ />
 <NullBool />
-<NullBool />
-",
+<NullBool />",
                 OutputType = AnalyzerOutputType.Class,
             };
 
@@ -173,13 +172,13 @@ End Namespace";
                 Type = "List(Of Boolean?)",
                 NameContains = string.Empty,
                 IfReadOnly = false,
-                Output = "<LB? />",
+                Output = "<LBnull />",
             });
 
             var expected = new AnalyzerOutput
             {
                 Name = "MyListOfNullables",
-                Output = @"<LB? />",
+                Output = @"<LBnull />",
                 OutputType = AnalyzerOutputType.Property,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicPropertiesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicPropertiesTests.cs
@@ -193,7 +193,8 @@ End Namespace";
             var expected = new AnalyzerOutput
             {
                 Name = "MyListProperty",
-                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\"></ItemsControl>",
+                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\">" + Environment.NewLine +
+                         "</ItemsControl>",
                 OutputType = AnalyzerOutputType.Property,
             };
 
@@ -225,7 +226,8 @@ End Namespace";
             var expected = new AnalyzerOutput
             {
                 Name = "MyListProperty2",
-                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty2}\"></ItemsControl>",
+                Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty2}\">" + Environment.NewLine +
+                         "</ItemsControl>",
                 OutputType = AnalyzerOutputType.Property,
             };
 
@@ -535,9 +537,9 @@ End Namespace";
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderDescription\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -587,8 +589,8 @@ End Namespace";
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -637,9 +639,9 @@ Namespace tests
 End Namespace";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -689,7 +691,7 @@ End Namespace";
 
             var expectedOutput = "<RadioButton Content=\"Active\" GroupName=\"OrderStatus\" />" + Environment.NewLine +
                                  "<RadioButton Content=\"OnHold\" GroupName=\"OrderStatus\" />" + Environment.NewLine +
-                                 "<RadioButton Content=\"Closed\" GroupName=\"OrderStatus\" />" + Environment.NewLine;
+                                 "<RadioButton Content=\"Closed\" GroupName=\"OrderStatus\" />";
 
             var expected = new AnalyzerOutput
             {
@@ -740,9 +742,9 @@ Namespace tests
 End Namespace";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -784,7 +786,7 @@ Namespace tests
 End Namespace";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -851,7 +853,7 @@ End Namespace";
             {
                 Name = "SomeList",
                 Output = @"<Dyno>
-<DymnProp Value="""" />
+    <DymnProp Value="""" />
 </Dyno>",
                 OutputType = AnalyzerOutputType.Property,
             };

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicSelectionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicSelectionTests.cs
@@ -43,7 +43,8 @@ End Namespace";
          + Environment.NewLine + "<TextBlock Text=\"Property3\" />"
          + Environment.NewLine + "<TextBox Text=\"{x:Bind Property4, Mode=TwoWay}\" />"
          + Environment.NewLine + "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Property5\" Value=\"{x:Bind Property5, Mode=TwoWay}\" />"
-         + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\"></ItemsControl>"
+         + Environment.NewLine + "<ItemsControl ItemsSource=\"{x:Bind Property6}\">"
+         + Environment.NewLine + "</ItemsControl>"
          + Environment.NewLine + "<TextBox Text=\"{x:Bind Property7, Mode=TwoWay}\" />"
          + Environment.NewLine + "<TextBox Text=\"{x:Bind Property8, Mode=TwoWay}\" />";
 
@@ -93,9 +94,9 @@ Namespace tests
 End Namespace";
 
             var expectedOutput = "<ComboBox>"
-         + Environment.NewLine + "<x:String>Active</x:String>"
-         + Environment.NewLine + "<x:String>OnHold</x:String>"
-         + Environment.NewLine + "<x:String>Closed</x:String>"
+         + Environment.NewLine + "    <x:String>Active</x:String>"
+         + Environment.NewLine + "    <x:String>OnHold</x:String>"
+         + Environment.NewLine + "    <x:String>Closed</x:String>"
          + Environment.NewLine + "</ComboBox>";
 
             var expected = new AnalyzerOutput
@@ -337,9 +338,9 @@ End Namespace";
             // This includes the readonly property as not yet filtering out
             // All types treated as fallback
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
-         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"SP_OrderDescription\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -406,7 +407,7 @@ End Namespace";
             {
                 Name = "SomeList",
                 Output = @"<Dyno>
-<DymnProp Value="""" />
+    <DymnProp Value="""" />
 </Dyno>",
                 OutputType = AnalyzerOutputType.Selection,
             };

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicStructsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetVisualBasicStructsTests.cs
@@ -40,8 +40,8 @@ Namespace tests
 End Namespace";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "<String Name=\"Property1\" />"
-         + Environment.NewLine + "<Int Name=\"Property2\" />"
+         + Environment.NewLine + "    <String Name=\"Property1\" />"
+         + Environment.NewLine + "    <Int Name=\"Property2\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new AnalyzerOutput
@@ -131,8 +131,7 @@ End Namespace";
             {
                 Name = "MyListProperty",
                 Output = @"<MyProperty1 />
-<MyProperty2 />
-",
+<MyProperty2 />",
                 OutputType = AnalyzerOutputType.Property,
             };
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/StarsRepresentCaretInDocsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/StarsRepresentCaretInDocsTests.cs
@@ -185,11 +185,11 @@ namespace RapidXamlToolkit.Tests.Analysis
             {
                 var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-                var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+                var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
                 Assert.AreEqual(expected.OutputType, actual.OutputType, $"Failure at {pos} ({startPos}-{endPos})");
                 Assert.AreEqual(expected.Name, actual.Name, $"Failure at {pos} ({startPos}-{endPos})");
-                Assert.AreEqual(expected.Output, actual.Output, $"Failure at {pos} ({startPos}-{endPos})");
+                StringAssert.AreEqual(expected.Output, actual.Output, $"Failure at {pos} ({startPos}-{endPos})");
 
                 positionsTested += 1;
             }
@@ -211,11 +211,11 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
             Assert.AreEqual(expected.OutputType, actual.OutputType);
             Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.Output, actual.Output);
+            StringAssert.AreEqual(expected.Output, actual.Output);
         }
 
         protected void PositionAtStarShouldProduceExpectedUsingAdditonalFiles(string code, AnalyzerOutput expected, bool isCSharp, Profile profileOverload, params string[] additionalCode)
@@ -245,11 +245,11 @@ namespace RapidXamlToolkit.Tests.Analysis
             var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer
                                     : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
             Assert.AreEqual(expected.OutputType, actual.OutputType);
             Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.Output, actual.Output);
+            StringAssert.AreEqual(expected.Output, actual.Output);
         }
 
         protected void PositionAtStarShouldProduceExpectedUsingAdditonalReferences(string code, AnalyzerOutput expected, bool isCSharp, Profile profileOverload, params string[] additionalReferences)
@@ -281,11 +281,11 @@ namespace RapidXamlToolkit.Tests.Analysis
             var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer
                                     : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
             Assert.AreEqual(expected.OutputType, actual.OutputType);
             Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.Output, actual.Output);
+            StringAssert.AreEqual(expected.Output, actual.Output);
         }
 
         protected void PositionAtStarShouldProduceExpectedUsingAdditonalLibraries(string code, AnalyzerOutput expected, bool isCSharp, Profile profileOverload, params string[] additionalLibraryPaths)
@@ -317,11 +317,11 @@ namespace RapidXamlToolkit.Tests.Analysis
             var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer
                                     : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
             Assert.AreEqual(expected.OutputType, actual.OutputType);
             Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.Output, actual.Output);
+            StringAssert.AreEqual(expected.Output, actual.Output);
         }
 
         protected void SelectionBetweenStarsShouldProduceExpected(string code, AnalyzerOutput expected, bool isCSharp, Profile profileOverload)
@@ -339,11 +339,11 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var analyzer = isCSharp ? new CSharpAnalyzer(DefaultTestLogger.Create()) as IDocumentAnalyzer : new VisualBasicAnalyzer(DefaultTestLogger.Create());
 
-            var actual = analyzer.GetSelectionOutput(syntaxTree.GetRoot(), semModel, startPos, endPos, profileOverload);
+            var actual = analyzer.GetSelectionOutput(syntaxTree.GetRoot(), semModel, startPos, endPos, new TestVisualStudioAbstraction().XamlIndent, profileOverload);
 
             Assert.AreEqual(expected.OutputType, actual.OutputType);
             Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.Output, actual.Output);
+            StringAssert.AreEqual(expected.Output, actual.Output);
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
@@ -42,14 +42,14 @@ namespace RapidXamlToolkit.Tests.CreateViews
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs");
+            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Files.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";
@@ -109,14 +109,14 @@ namespace App.Files
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs");
+            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";
@@ -181,14 +181,14 @@ namespace App.Views
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.cs");
+            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.cs", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
@@ -42,7 +42,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs", 4);
+            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs");
 
             var expectedXaml = @"<Page
     x:Class=""App.Files.TestPage"">
@@ -109,7 +109,7 @@ namespace App.Files
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs", 4);
+            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs");
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
@@ -181,7 +181,7 @@ namespace App.Views
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.cs", 4);
+            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.cs");
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
@@ -44,7 +44,7 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb", 4);
+            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb");
 
             var expectedXaml = @"<Page
     x:Class=""App.Files.TestPage"">
@@ -113,7 +113,7 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.vb", 4);
+            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.vb");
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
@@ -187,7 +187,7 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.vb", 4);
+            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.vb");
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
@@ -44,14 +44,14 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb");
+            await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Files.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";
@@ -113,14 +113,14 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.vb");
+            await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.vb", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";
@@ -187,14 +187,14 @@ End Class",
 
             var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
 
-            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.vb");
+            await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.vb", 4);
 
             var expectedXaml = @"<Page
     x:Class=""App.Views.TestPage"">
     <Grid>
         <StackPanel>
-<TextBlock FB=""True"" Text=""OnlyProperty"" />
-</StackPanel>
+            <TextBlock FB=""True"" Text=""OnlyProperty"" />
+        </StackPanel>
     </Grid>
 </Page>
 ";

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Extensions/StringExtensionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Extensions/StringExtensionTests.cs
@@ -419,5 +419,108 @@ namespace RapidXamlToolkit.Tests.Extensions
         {
             Assert.AreEqual("something X", "somethingX".AddSpacesToCamelCase());
         }
+
+        [TestMethod]
+        public void FormatXaml_OneElementNoIndents()
+        {
+            var origin = @"<TextBlock Text=""SomeProperty"" />";
+            var expected = @"<TextBlock Text=""SomeProperty"" />";
+
+            var formatted = origin.FormatXaml(4);
+
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestMethod]
+        public void FormatXaml_OneElementWithSubItems()
+        {
+            var origin = @"<StackPanel>
+<TextBlock Text=""SomeProperty"" />
+</StackPanel>";
+            var expected = @"<StackPanel>
+    <TextBlock Text=""SomeProperty"" />
+</StackPanel>";
+
+            var formatted = origin.FormatXaml(4);
+
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestMethod]
+        public void FormatXaml_OneElementWithSubItems_SmallIndent()
+        {
+            var origin = @"<StackPanel>
+<TextBlock Text=""SomeProperty"" />
+</StackPanel>";
+            var expected = @"<StackPanel>
+  <TextBlock Text=""SomeProperty"" />
+</StackPanel>";
+
+            var formatted = origin.FormatXaml(2);
+
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestMethod]
+        public void FormatXaml_TwoElementNoIndents()
+        {
+            var origin = @"<TextBlock Text=""SomeProperty"" />
+<TextBlock Text=""AnotherProperty"" />";
+            var expected = @"<TextBlock Text=""SomeProperty"" />
+<TextBlock Text=""AnotherProperty"" />";
+
+            var formatted = origin.FormatXaml(4);
+
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestMethod]
+        public void FormatXaml_FiveElementNoIndents()
+        {
+            var origin = @"<TextBlock Text=""SomeProperty"" />
+<TextBlock Text=""AProperty"" />
+<TextBlock Text=""AnotherProperty"" />
+<TextBlock Text=""FourthProperty"" />
+<TextBlock Text=""FinalProperty"" />";
+            var expected = @"<TextBlock Text=""SomeProperty"" />
+<TextBlock Text=""AProperty"" />
+<TextBlock Text=""AnotherProperty"" />
+<TextBlock Text=""FourthProperty"" />
+<TextBlock Text=""FinalProperty"" />";
+
+            var formatted = origin.FormatXaml(4);
+
+            Assert.AreEqual(expected, formatted);
+        }
+
+        [TestMethod]
+        public void FormatXaml_ClassWithSubItems()
+        {
+            var originalInput = "<Grid>"
+         + Environment.NewLine + "<ListView><ListView.ItemTemplate><DataTemplate><StackPanel>"
+         + Environment.NewLine + "<TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "<TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "<TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>"
+         + Environment.NewLine + "</Grid>";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <ListView>"
+         + Environment.NewLine + "        <ListView.ItemTemplate>"
+         + Environment.NewLine + "            <DataTemplate>"
+         + Environment.NewLine + "                <StackPanel>"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderId\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderPlacedDateTime\" />"
+         + Environment.NewLine + "                    <TextBlock Text=\"SP_OrderDescription\" />"
+         + Environment.NewLine + "                </StackPanel>"
+         + Environment.NewLine + "            </DataTemplate>"
+         + Environment.NewLine + "        </ListView.ItemTemplate>"
+         + Environment.NewLine + "    </ListView>"
+         + Environment.NewLine + "</Grid>";
+
+            var formatted = originalInput.FormatXaml(4);
+
+            Assert.AreEqual(expectedOutput, formatted);
+        }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,6 +22,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         private const string ReadWriteIntOutput = "<ReadWriteIntOutput />";
 
         private const string StringPropertyName = "String";
+        private const int UnusedIndentValue = 3;
 
         private readonly Profile testProfile;
 
@@ -76,7 +78,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetsNonFilteredOutputIfNameDoesntMatch()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "MyProperty", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "MyProperty", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWriteStringOutput.Replace("$name$", "MyProperty"), result);
         }
@@ -84,7 +86,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void ReadWritePropertyIsIdentified()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "AnotherProperty", true);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "AnotherProperty", true, UnusedIndentValue);
 
             Assert.AreEqual(ReadonlyStringOutput.Replace("$name$", "AnotherProperty"), result);
         }
@@ -92,7 +94,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void SingleNameContainsIsIdentified()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "number1", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "number1", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -100,7 +102,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void MultipleNameContainsIsIdentified()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "EnteredPassword", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "EnteredPassword", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWritePasswordStringOutput.Replace("$name$", "EnteredPassword"), result);
         }
@@ -108,7 +110,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void ReadOnlyTakesPriorityOverContains()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "EnteredPwd", true);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "string", "EnteredPwd", true, UnusedIndentValue);
 
             Assert.AreEqual(ReadonlyStringOutput.Replace("$name$", "EnteredPwd"), result);
         }
@@ -116,7 +118,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void TypeNameIsCaseInsensitive()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "INT", "number1", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "INT", "number1", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -124,7 +126,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void NameContainsIsCaseInsensitive()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "Number1", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "Number1", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -132,7 +134,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void NoNameContainsIsIdentified()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "numero2", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "int", "numero2", false, UnusedIndentValue);
 
             Assert.AreEqual(ReadWriteIntOutput, result);
         }
@@ -140,7 +142,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetFallbackIfTypeNotMapped()
         {
-            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "bool", "IsAdmin", false);
+            var result = AnalyzerBase.GetPropertyOutput(this.testProfile, "bool", "IsAdmin", false, UnusedIndentValue);
 
             Assert.AreEqual(FallbackOutput, result);
         }
@@ -160,15 +162,18 @@ namespace RapidXamlToolkit.Tests.Formatting
                     {
                         Type = StringPropertyName,
                         NameContains = "",
-                        Output = "<TextBlock Text=\"$name$\" Grid.Row=\"$incint$\"><TextBlock Text=\"$name$\" Grid.Row=\"$incint$\" />",
+                        Output = "<TextBlock Text=\"$name$\" Grid.Row=\"$incint$\" /><TextBlock Text=\"$name$\" Grid.Row=\"$incint$\" />",
                         IfReadOnly = false,
                     },
                 },
             };
 
-            var result = AnalyzerBase.GetPropertyOutput(gridProfile, StringPropertyName, "MyProperty", false);
+            var result = AnalyzerBase.GetPropertyOutput(gridProfile, StringPropertyName, "MyProperty", false, UnusedIndentValue);
 
-            Assert.AreEqual("<TextBlock Text=\"MyProperty\" Grid.Row=\"1\"><TextBlock Text=\"MyProperty\" Grid.Row=\"2\" />", result);
+            var expected = "<TextBlock Text=\"MyProperty\" Grid.Row=\"1\" />" + Environment.NewLine +
+                           "<TextBlock Text=\"MyProperty\" Grid.Row=\"2\" />";
+
+            StringAssert.AreEqual(expected, result);
         }
 
         [TestMethod]
@@ -191,7 +196,7 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = AnalyzerBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: true);
+            var result = AnalyzerBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: true, indent: UnusedIndentValue);
 
             Assert.AreEqual("<ReadAndWrite />", result);
         }
@@ -216,7 +221,7 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = AnalyzerBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: false);
+            var result = AnalyzerBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: false, indent: UnusedIndentValue);
 
             Assert.AreEqual("<Fallback />", result);
         }
@@ -297,7 +302,7 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = AnalyzerBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false);
+            var result = AnalyzerBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false, indent: UnusedIndentValue);
 
             Assert.AreEqual("<Wildcard />", result);
         }
@@ -329,7 +334,7 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = AnalyzerBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false);
+            var result = AnalyzerBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false, indent: UnusedIndentValue);
 
             Assert.AreEqual("<ListOfStrings />", result);
         }
@@ -346,7 +351,7 @@ namespace RapidXamlToolkit.Tests.Formatting
                 Output = "$namewithspaces$",
             });
 
-            var result = AnalyzerBase.GetPropertyOutput(profile, "string", "MyProperty", isReadOnly: false);
+            var result = AnalyzerBase.GetPropertyOutput(profile, "string", "MyProperty", isReadOnly: false, indent: UnusedIndentValue);
 
             Assert.AreEqual("My Property", result);
         }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/DefaultConfigurationTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/DefaultConfigurationTests.cs
@@ -57,6 +57,9 @@ namespace RapidXamlToolkit.Tests.Options
                 Assert.IsNotNull(profile.Datacontext.CodeBehindPageContent, nameof(DatacontextSettings.CodeBehindPageContent));
                 Assert.IsNotNull(profile.Datacontext.DefaultCodeBehindConstructor, nameof(DatacontextSettings.DefaultCodeBehindConstructor));
                 Assert.IsNotNull(profile.Datacontext.XamlPageAttribute, nameof(DatacontextSettings.XamlPageAttribute));
+
+                Assert.IsNotNull(profile.General, $"{nameof(Profile.General)} in profile {profile.Name}");
+                Assert.IsNotNull(profile.General.AttemptAutomaticDocumentFormatting, $"{nameof(Profile.General.AttemptAutomaticDocumentFormatting)} in profile {profile.Name}");
             }
         }
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="SetDatacontext\SetDatacontextInCSharpTests.cs" />
     <Compile Include="SetDatacontext\SetDatacontextInVisualBasicTests.cs" />
     <Compile Include="SetDatacontext\SetDatacontextInXamlTests.cs" />
+    <Compile Include="StringAssert.cs" />
     <Compile Include="TestFileSystem.cs" />
     <Compile Include="TestProfile.cs" />
     <Compile Include="TestVisualStudioAbstraction.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RapidXamlToolkit.Tests
+{
+    // Provides more detailed output when compared strings are not equal.
+    // Intended to make spotting differences easier.
+    public static class StringAssert
+    {
+        public static void AreEqual(string expected, string actual, string message = "")
+        {
+            if (expected == actual)
+            {
+                Assert.IsTrue(true);
+            }
+            else
+            {
+                var errorMessage = string.Empty;
+
+                if (expected.TrimStart() == actual)
+                {
+                    errorMessage = "Whitespace missing at start of output.";
+                }
+                else if (expected == actual.TrimStart())
+                {
+                    errorMessage = "Additional whitespace at start of output.";
+                }
+                else if (expected.TrimEnd() == actual)
+                {
+                    errorMessage = "Whitespace missing at end of output.";
+                }
+                else if (expected == actual.TrimEnd())
+                {
+                    errorMessage = "Additional whitespace at end of output.";
+                }
+
+                if (string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    var aLines = actual.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                    var eLines = expected.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+
+                    if (aLines.Length != eLines.Length)
+                    {
+                        errorMessage = $"Expected {eLines.Length} lines in output but had {aLines.Length}.";
+                    }
+                    else
+                    {
+                        for (int i = 0; i < eLines.Length; i++)
+                        {
+                            if (eLines[i] == aLines[i])
+                            {
+                                continue;
+                            }
+
+                            if (eLines[i].TrimStart() == aLines[i])
+                            {
+                                errorMessage = $"Whitespace missing at start of line {i + 1} of output.";
+                                break;
+                            }
+                            else if (eLines[i] == aLines[i].TrimStart())
+                            {
+                                errorMessage = $"Additional whitespace at start of line {i + 1} of output.";
+                                break;
+                            }
+                            else if (eLines[i].TrimEnd() == aLines[i])
+                            {
+                                errorMessage = $"Whitespace missing at end of line {i + 1} of output.";
+                                break;
+                            }
+                            else if (eLines[i] == aLines[i].TrimEnd())
+                            {
+                                errorMessage = $"Additional whitespace at end of line {i + 1} of output.";
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    var i = 0;
+                    while (i < actual.Length && i < expected.Length)
+                    {
+                        if (expected[i] != actual[i])
+                        {
+                            errorMessage = $"Output first differs at position {i} ({expected[i]}-{actual[i]}).";
+
+                            if (actual.Contains(Environment.NewLine))
+                            {
+                                var lineNo = actual.Substring(0, i).Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
+                                errorMessage += $" On line {lineNo}.";
+                            }
+
+                            break;
+                        }
+
+                        i++;
+                    }
+                }
+
+                Assert.Fail($"{Environment.NewLine}{errorMessage}{Environment.NewLine}Expected:<{expected}>.{Environment.NewLine}Actual<{actual}>.{Environment.NewLine}{message}");
+            }
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/TestVisualStudioAbstraction.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/TestVisualStudioAbstraction.cs
@@ -25,6 +25,8 @@ namespace RapidXamlToolkit.Tests
 
         public bool DocumentIsCSharp { get; set; } = false;
 
+        public int XamlIndent { get; set; } = 4;
+
         public ProjectWrapper GetActiveProject()
         {
             return this.ActiveProject;
@@ -65,6 +67,12 @@ namespace RapidXamlToolkit.Tests
         public bool ActiveDocumentIsCSharp()
         {
             return this.DocumentIsCSharp;
+        }
+
+        public async Task<int> GetXamlIndentAsync()
+        {
+            await Task.CompletedTask;
+            return this.XamlIndent;
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/app.config
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -45,6 +45,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/AnalyzerBase.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/AnalyzerBase.cs
@@ -45,11 +45,11 @@ namespace RapidXamlToolkit.Analyzers
             return configuredSettings.ActualSettings;
         }
 
-        public static (string output, int counter) GetPropertyOutputAndCounterForActiveProfile(PropertyDetails property, int numericSubstitute, Func<(List<string> strings, int count)> getSubPropertyOutput = null)
+        public static (string output, int counter) GetPropertyOutputAndCounterForActiveProfile(PropertyDetails property, int numericSubstitute, int indent, Func<(List<string> strings, int count)> getSubPropertyOutput = null)
         {
             var settings = GetSettings();
             var activeProfile = settings.GetActiveProfile();
-            return GetPropertyOutputAndCounter(activeProfile, property, numericSubstitute, getSubPropertyOutput);
+            return GetPropertyOutputAndCounter(activeProfile, property, numericSubstitute, indent, getSubPropertyOutput);
         }
 
         public static string GetClassGroupingForActiveProfile()
@@ -63,18 +63,18 @@ namespace RapidXamlToolkit.Analyzers
             return result;
         }
 
-        public static string GetPropertyOutput(Profile profile, string type, string name, bool isReadOnly, Func<(List<string> strings, int count)> getSubProperties = null)
+        public static string GetPropertyOutput(Profile profile, string type, string name, bool isReadOnly, int indent, Func<(List<string> strings, int count)> getSubProperties = null)
         {
-            return GetPropertyOutputAndCounter(profile, new PropertyDetails { PropertyType = type, Name = name, IsReadOnly = isReadOnly }, 1, getSubProperties).output;
+            return GetPropertyOutputAndCounter(profile, new PropertyDetails { PropertyType = type, Name = name, IsReadOnly = isReadOnly }, 1, indent, getSubProperties).output;
         }
 
-        public static (string output, int counter) GetSubPropertyOutputAndCounter(Profile profile, string name, int numericSubstitute)
+        public static (string output, int counter) GetSubPropertyOutputAndCounter(Profile profile, string name, int numericSubstitute, int indent)
         {
             // Type is blank as it's can't be used in a subproperty
-            return FormatOutput(profile, profile.SubPropertyOutput, type: string.Empty, name: name, numericSubstitute: numericSubstitute, symbol: null, getSubPropertyOutput: null);
+            return FormatOutput(profile, profile.SubPropertyOutput, type: string.Empty, name: name, numericSubstitute: numericSubstitute, symbol: null, indent: indent, getSubPropertyOutput: null);
         }
 
-        public static (string output, int counter) GetPropertyOutputAndCounter(Profile profile, PropertyDetails property, int numericSubstitute, Func<(List<string> strings, int count)> getSubPropertyOutput = null)
+        public static (string output, int counter) GetPropertyOutputAndCounter(Profile profile, PropertyDetails property, int numericSubstitute, int indent, Func<(List<string> strings, int count)> getSubPropertyOutput = null)
         {
             var mappingOfInterest = GetMappingOfInterest(profile, property);
 
@@ -112,10 +112,10 @@ namespace RapidXamlToolkit.Analyzers
                 return (null, numericSubstitute);
             }
 
-            return FormatOutput(profile, rawOutput, property.PropertyType, property.Name, numericSubstitute, property.Symbol, getSubPropertyOutput);
+            return FormatOutput(profile, rawOutput, property.PropertyType, property.Name, numericSubstitute, property.Symbol, indent, getSubPropertyOutput);
         }
 
-        public static (string output, int counter) FormatOutput(Profile profile, string rawOutput, string type, string name, int numericSubstitute, ITypeSymbol symbol, Func<(List<string> strings, int count)> getSubPropertyOutput)
+        public static (string output, int counter) FormatOutput(Profile profile, string rawOutput, string type, string name, int numericSubstitute, ITypeSymbol symbol, int indent, Func<(List<string> strings, int count)> getSubPropertyOutput)
         {
             Logger?.RecordInfo(StringRes.Info_FormattingOutputForProperty.WithParams(name));
 
@@ -292,7 +292,9 @@ namespace RapidXamlToolkit.Analyzers
                 result = string.Empty;
             }
 
-            return (result, numericSubstitute);
+            var finalResult = result.FormatXaml(indent);
+
+            return (finalResult, numericSubstitute);
         }
 
         public static Mapping GetMappingOfInterest(Profile profile, PropertyDetails property)

--- a/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/CSharpAnalyzer.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/CSharpAnalyzer.cs
@@ -24,7 +24,7 @@ namespace RapidXamlToolkit.Analyzers
 
         public override string FileExtension { get; } = "cs";
 
-        public static (List<string> strings, int count) GetSubPropertyOutput(PropertyDetails property, Profile profile, SemanticModel semModel)
+        public static (List<string> strings, int count) GetSubPropertyOutput(PropertyDetails property, Profile profile, SemanticModel semModel, int indent)
         {
             var result = new List<string>();
 
@@ -40,7 +40,7 @@ namespace RapidXamlToolkit.Analyzers
                 {
                     Logger?.RecordInfo(StringRes.Info_GettingSubPropertyOutput.WithParams(subprop.Name));
 
-                    var (output, counter) = GetSubPropertyOutputAndCounter(profile, subprop.Name, numericSubstitute: numericSubstitute);
+                    var (output, counter) = GetSubPropertyOutputAndCounter(profile, subprop.Name, numericSubstitute: numericSubstitute, indent: indent);
 
                     numericSubstitute = counter;
                     result.Add(output);
@@ -51,7 +51,7 @@ namespace RapidXamlToolkit.Analyzers
                 Logger?.RecordInfo(StringRes.Info_PropertyTypeHasNoSubProperties.WithParams(property.Name, property.PropertyType));
 
                 // There are no subproperties so leave blank
-                var (output, counter) = GetSubPropertyOutputAndCounter(profile, string.Empty, numericSubstitute: numericSubstitute);
+                var (output, counter) = GetSubPropertyOutputAndCounter(profile, string.Empty, numericSubstitute: numericSubstitute, indent: indent);
 
                 numericSubstitute = counter;
                 result.Add(output);
@@ -164,7 +164,7 @@ namespace RapidXamlToolkit.Analyzers
             return (propertyNode, classNode);
         }
 
-        public AnalyzerOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition, Profile profileOverload = null)
+        public AnalyzerOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition, int indent, Profile profileOverload = null)
         {
             Logger?.RecordInfo(StringRes.Info_GetSingleItemOutput);
             var (propertyNode, classNode) = GetNodeUnderCaret(documentRoot, caretPosition);
@@ -265,10 +265,12 @@ namespace RapidXamlToolkit.Analyzers
                     output.Append($"</{FormattedClassGroupingCloser(classGrouping)}>");
                 }
 
+                var finalOutput = output.ToString().FormatXaml(indent);
+
                 return new AnalyzerOutput
                 {
                     Name = className,
-                    Output = output.ToString(),
+                    Output = finalOutput,
                     OutputType = AnalyzerOutputType.Class,
                 };
             }
@@ -277,7 +279,7 @@ namespace RapidXamlToolkit.Analyzers
             return AnalyzerOutput.Empty;
         }
 
-        public AnalyzerOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd, Profile profileOverload = null)
+        public AnalyzerOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd, int indent, Profile profileOverload = null)
         {
             Logger?.RecordInfo(StringRes.Info_GetSelectionOutput);
 
@@ -315,8 +317,8 @@ namespace RapidXamlToolkit.Analyzers
 
                 Logger?.RecordInfo(StringRes.Info_AddingPropertyToOutput.WithParams(propDetails.Name));
                 var toAdd = profileOverload == null
-                        ? GetPropertyOutputAndCounterForActiveProfile(propDetails, numericCounter, () => GetSubPropertyOutput(propDetails, GetSettings().GetActiveProfile(), semModel))
-                        : GetPropertyOutputAndCounter(profileOverload, propDetails, numericCounter, () => GetSubPropertyOutput(propDetails, profileOverload, semModel));
+                        ? GetPropertyOutputAndCounterForActiveProfile(propDetails, numericCounter, indent, () => GetSubPropertyOutput(propDetails, GetSettings().GetActiveProfile(), semModel, indent))
+                        : GetPropertyOutputAndCounter(profileOverload, propDetails, numericCounter, indent, () => GetSubPropertyOutput(propDetails, profileOverload, semModel, indent));
 
                 if (!string.IsNullOrWhiteSpace(toAdd.output))
                 {
@@ -348,11 +350,11 @@ namespace RapidXamlToolkit.Analyzers
             }
         }
 
-        private static (string output, string name, int counter) GetOutputToAdd(SemanticModel semModel, Profile profileOverload, PropertyDetails prop, int numericCounter = 0)
+        private static (string output, string name, int counter) GetOutputToAdd(SemanticModel semModel, Profile profileOverload, PropertyDetails prop, int numericCounter = 0, int indent = 4)
         {
             var (output, counter) = profileOverload == null
-                ? GetPropertyOutputAndCounterForActiveProfile(prop, numericCounter, () => GetSubPropertyOutput(prop, GetSettings().GetActiveProfile(), semModel))
-                : GetPropertyOutputAndCounter(profileOverload, prop, numericCounter, () => GetSubPropertyOutput(prop, profileOverload, semModel));
+                ? GetPropertyOutputAndCounterForActiveProfile(prop, numericCounter, indent, () => GetSubPropertyOutput(prop, GetSettings().GetActiveProfile(), semModel, indent))
+                : GetPropertyOutputAndCounter(profileOverload, prop, numericCounter, indent, () => GetSubPropertyOutput(prop, profileOverload, semModel, indent));
 
             return (output, prop.Name, counter);
         }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/IDocumentAnalyzer.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Analyzers/IDocumentAnalyzer.cs
@@ -8,8 +8,8 @@ namespace RapidXamlToolkit.Analyzers
 {
     public interface IDocumentAnalyzer
     {
-        AnalyzerOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition, Profile profileOverload = null);
+        AnalyzerOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition, int indent, Profile profileOverload = null);
 
-        AnalyzerOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd, Profile profileOverload = null);
+        AnalyzerOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd, int indent, Profile profileOverload = null);
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/BaseCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/BaseCommand.cs
@@ -79,5 +79,16 @@ namespace RapidXamlToolkit.Commands
                 return indent.Default;
             }
         }
+
+        protected void SuppressAnyException(Action action)
+        {
+            try
+            {
+                action.Invoke();
+            }
+            catch (Exception)
+            {
+            }
+        }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/BaseCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/BaseCommand.cs
@@ -31,9 +31,7 @@ namespace RapidXamlToolkit.Commands
 
         protected static async Task<Microsoft.VisualStudio.Text.Editor.IWpfTextView> GetTextViewAsync(IAsyncServiceProvider serviceProvider)
         {
-            var textManager = await serviceProvider.GetServiceAsync(typeof(SVsTextManager)) as IVsTextManager;
-
-            if (textManager == null)
+            if (!(await serviceProvider.GetServiceAsync(typeof(SVsTextManager)) is IVsTextManager textManager))
             {
                 return null;
             }
@@ -55,6 +53,31 @@ namespace RapidXamlToolkit.Commands
         {
             var componentModel = await serviceProvider.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
             return componentModel.GetService<IVsEditorAdaptersFactoryService>();
+        }
+
+        protected async Task<int> GetXamlIndentAsync(IAsyncServiceProvider serviceProvider)
+        {
+            try
+            {
+                var xamlLanguageGuid = new Guid("CD53C9A1-6BC2-412B-BE36-CC715ED8DD41");
+                var languagePreferences = new LANGPREFERENCES3[1];
+
+                languagePreferences[0].guidLang = xamlLanguageGuid;
+
+                var textManager = await serviceProvider.GetServiceAsync(typeof(SVsTextManager)) as IVsTextManager4;
+
+                textManager.GetUserPreferences4(pViewPrefs: null, pLangPrefs: languagePreferences, pColorPrefs: null);
+
+                return (int)languagePreferences[0].uIndentSize;
+            }
+            catch (Exception exc)
+            {
+                this.Logger.RecordException(exc);
+
+                var indent = new Microsoft.VisualStudio.Text.Editor.IndentSize();
+
+                return indent.Default;
+            }
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
@@ -170,8 +170,9 @@ namespace RapidXamlToolkit.Commands
                 var profile = AnalyzerBase.GetSettings().GetActiveProfile();
 
                 var logic = new CreateViewCommandLogic(profile, this.Logger, new VisualStudioAbstraction(dte, componentModel));
+                var indent = await this.GetXamlIndentAsync(this.ServiceProvider);
 
-                await logic.ExecuteAsync(this.SelectedFileName);
+                await logic.ExecuteAsync(this.SelectedFileName, indent);
 
                 if (logic.CreateView)
                 {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
@@ -165,14 +165,12 @@ namespace RapidXamlToolkit.Commands
 
                 this.Logger?.RecordInfo(StringRes.Info_AttemptingToCreateView);
                 var dte = await this.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
-                var componentModel = await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
 
                 var profile = AnalyzerBase.GetSettings().GetActiveProfile();
 
-                var logic = new CreateViewCommandLogic(profile, this.Logger, new VisualStudioAbstraction(dte, componentModel));
-                var indent = await this.GetXamlIndentAsync(this.ServiceProvider);
+                var logic = new CreateViewCommandLogic(profile, this.Logger, new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte));
 
-                await logic.ExecuteAsync(this.SelectedFileName, indent);
+                await logic.ExecuteAsync(this.SelectedFileName);
 
                 if (logic.CreateView)
                 {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
@@ -12,8 +12,6 @@ namespace RapidXamlToolkit.Commands
 {
     public class CreateViewCommandLogic
     {
-        private const bool FormatXaml = true;
-
         private readonly Profile profile;
         private readonly ILogger logger;
         private readonly IFileSystemAbstraction fileSystem;
@@ -41,7 +39,7 @@ namespace RapidXamlToolkit.Commands
 
         public string ViewFolder { get; private set; }
 
-        public async Task ExecuteAsync(string selectedFileName, int indent = 0)
+        public async Task ExecuteAsync(string selectedFileName)
         {
             var vmProj = this.vs.GetActiveProject();
 
@@ -69,8 +67,10 @@ namespace RapidXamlToolkit.Commands
 
             if (analyzer != null)
             {
+                var indent = await this.vs.GetXamlIndentAsync();
+
                 // IndexOf is allowing for "class " in C# and "Class " in VB
-                var analyzerOutput = ((IDocumentAnalyzer)analyzer).GetSingleItemOutput(await syntaxTree.GetRootAsync(), semModel, fileContents.IndexOf("lass "), this.profile);
+                var analyzerOutput = ((IDocumentAnalyzer)analyzer).GetSingleItemOutput(await syntaxTree.GetRootAsync(), semModel, fileContents.IndexOf("lass "), indent, this.profile);
 
                 var config = this.profile.ViewGeneration;
 
@@ -142,6 +142,7 @@ namespace RapidXamlToolkit.Commands
 
                     if (this.CreateView)
                     {
+                        // Allow for different namespace conventions
                         var viewNamespace = analyzer is CSharpAnalyzer
                                           ? $"{viewProjName}.{config.XamlFileDirectoryName}".TrimEnd('.')
                                           : $"{config.XamlFileDirectoryName}".TrimEnd('.');
@@ -152,24 +153,14 @@ namespace RapidXamlToolkit.Commands
 
                         this.XamlFileContents = this.ReplacePlaceholders(config.XamlPlaceholder, replacementValues);
 
-                        // This check is here to make it easy to remove formatting, or make it configuable, if desired X-Ref #62
-                        if (FormatXaml)
-                        {
-                            var formattedXaml = analyzerOutput.Output.FormatXaml(indent);
+                        var formattedXaml = analyzerOutput.Output.FormatXaml(indent);
 
-                            var placeholderPos = this.XamlFileContents.IndexOf(Placeholder.GeneratedXAML);
-                            var startOfPlaceholderLine = this.XamlFileContents.Substring(0, placeholderPos).LastIndexOf(Environment.NewLine);
+                        var placeholderPos = this.XamlFileContents.IndexOf(Placeholder.GeneratedXAML);
+                        var startOfPlaceholderLine = this.XamlFileContents.Substring(0, placeholderPos).LastIndexOf(Environment.NewLine);
 
-                            var insertIndent = placeholderPos - startOfPlaceholderLine - Environment.NewLine.Length;
+                        var insertIndent = placeholderPos - startOfPlaceholderLine - Environment.NewLine.Length;
 
-                            this.XamlFileContents = this.XamlFileContents.Replace(Placeholder.GeneratedXAML, formattedXaml.Replace(Environment.NewLine, Environment.NewLine + new string(' ', insertIndent)).Trim());
-                        }
-                        else
-                        {
-#pragma warning disable CS0162 // Unreachable code detected
-                            this.XamlFileContents = this.XamlFileContents.Replace(Placeholder.GeneratedXAML, analyzerOutput.Output);
-#pragma warning restore CS0162 // Unreachable code detected
-                        }
+                        this.XamlFileContents = this.XamlFileContents.Replace(Placeholder.GeneratedXAML, formattedXaml.Replace(Environment.NewLine, Environment.NewLine + new string(' ', insertIndent)).Trim());
 
                         this.CodeFileContents = this.ReplacePlaceholders(config.CodePlaceholder, replacementValues);
                     }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
@@ -166,7 +166,9 @@ namespace RapidXamlToolkit.Commands
                         }
                         else
                         {
+#pragma warning disable CS0162 // Unreachable code detected
                             this.XamlFileContents = this.XamlFileContents.Replace(Placeholder.GeneratedXAML, analyzerOutput.Output);
+#pragma warning restore CS0162 // Unreachable code detected
                         }
 
                         this.CodeFileContents = this.ReplacePlaceholders(config.CodePlaceholder, replacementValues);

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/GetXamlFromCodeWindowBaseCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/GetXamlFromCodeWindowBaseCommand.cs
@@ -40,6 +40,9 @@ namespace RapidXamlToolkit.Commands
 
                 var semanticModel = await document.GetSemanticModelAsync();
 
+                var vs = new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte);
+                var xamlIndent = await vs.GetXamlIndentAsync();
+
                 IDocumentAnalyzer analyzer = null;
 
                 if (activeDocument.Language == "CSharp")
@@ -52,8 +55,8 @@ namespace RapidXamlToolkit.Commands
                 }
 
                 result = isSelection
-                    ? analyzer?.GetSelectionOutput(await document.GetSyntaxRootAsync(), semanticModel, selection.Start.Position, selection.End.Position)
-                    : analyzer?.GetSingleItemOutput(await document.GetSyntaxRootAsync(), semanticModel, caretPosition.Position);
+                    ? analyzer?.GetSelectionOutput(await document.GetSyntaxRootAsync(), semanticModel, selection.Start.Position, selection.End.Position, xamlIndent)
+                    : analyzer?.GetSingleItemOutput(await document.GetSyntaxRootAsync(), semanticModel, caretPosition.Position, xamlIndent);
             }
             else
             {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/IVisualStudioAbstraction.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/IVisualStudioAbstraction.cs
@@ -23,5 +23,7 @@ namespace RapidXamlToolkit.Commands
         string GetActiveDocumentText();
 
         bool ActiveDocumentIsCSharp();
+
+        Task<int> GetXamlIndentAsync();
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/SetDatacontextCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/SetDatacontextCommand.cs
@@ -153,6 +153,8 @@ namespace RapidXamlToolkit.Commands
                         }
                     }
                 }
+
+                this.SuppressAnyException(() => dte.FormatDocument(profile));
             }
             catch (Exception exc)
             {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/SetDatacontextCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/SetDatacontextCommand.cs
@@ -58,7 +58,7 @@ namespace RapidXamlToolkit.Commands
                         var profile = settings.GetActiveProfile();
                         var dte = await Instance.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
 
-                        var logic = new SetDataContextCommandLogic(profile, this.Logger, new VisualStudioAbstraction(dte));
+                        var logic = new SetDataContextCommandLogic(profile, this.Logger, new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte));
 
                         showCommandButton = logic.ShouldEnableCommand();
                     }
@@ -86,7 +86,7 @@ namespace RapidXamlToolkit.Commands
 
                 var dte = await Instance.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
 
-                var logic = new SetDataContextCommandLogic(profile, this.Logger, new VisualStudioAbstraction(dte));
+                var logic = new SetDataContextCommandLogic(profile, this.Logger, new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte));
 
                 var inXamlDoc = dte.ActiveDocument.Name.EndsWith(".xaml", StringComparison.InvariantCultureIgnoreCase);
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/VisualStudioAbstraction.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/VisualStudioAbstraction.cs
@@ -9,22 +9,24 @@ using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices;
-using Microsoft.VisualStudio.Text.Editor;
-using TextDocument = EnvDTE.TextDocument;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.TextManager.Interop;
+using RapidXamlToolkit.Logging;
 
 namespace RapidXamlToolkit.Commands
 {
     public class VisualStudioAbstraction : IVisualStudioAbstraction
     {
+        private readonly ILogger logger;
+        private readonly IAsyncServiceProvider serviceProvider;
         private readonly DTE dte;
-        private readonly IComponentModel componentModel;
-        private readonly IWpfTextView textView;
 
-        public VisualStudioAbstraction(DTE dte, IComponentModel componentModel = null, IWpfTextView textView = null)
+        // Pass in the DTE even though could get it from the ServiceProvider because it's needed in constructors but usage is async
+        public VisualStudioAbstraction(ILogger logger, IAsyncServiceProvider serviceProvider, DTE dte)
         {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.dte = dte ?? throw new ArgumentNullException(nameof(dte));
-            this.componentModel = componentModel;
-            this.textView = textView;
         }
 
         public string GetActiveDocumentFileName()
@@ -36,7 +38,7 @@ namespace RapidXamlToolkit.Commands
         {
             var activeDoc = this.dte.ActiveDocument;
 
-            if (activeDoc.Object("TextDocument") is TextDocument objectDoc)
+            if (activeDoc.Object("TextDocument") is EnvDTE.TextDocument objectDoc)
             {
                 var docText = objectDoc.StartPoint.CreateEditPoint().GetText(objectDoc.EndPoint);
 
@@ -53,7 +55,8 @@ namespace RapidXamlToolkit.Commands
 
         public async Task<(SyntaxTree syntaxTree, SemanticModel semModel)> GetDocumentModelsAsync(string fileName)
         {
-            var visualStudioWorkspace = this.componentModel?.GetService<VisualStudioWorkspace>();
+            var componentModel = await this.serviceProvider.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+            var visualStudioWorkspace = componentModel?.GetService<VisualStudioWorkspace>();
 
             if (visualStudioWorkspace != null)
             {
@@ -75,11 +78,6 @@ namespace RapidXamlToolkit.Commands
             var semModel = await document.GetSemanticModelAsync();
 
             return (syntaxTree, semModel);
-        }
-
-        public IWpfTextView GetActiveTextView()
-        {
-            return this.textView;
         }
 
         public ProjectWrapper GetProject(string projectName)
@@ -109,6 +107,31 @@ namespace RapidXamlToolkit.Commands
         public bool ActiveDocumentIsCSharp()
         {
             return this.dte.ActiveDocument.Language == "CSharp";
+        }
+
+        public async Task<int> GetXamlIndentAsync()
+        {
+            try
+            {
+                var xamlLanguageGuid = new Guid("CD53C9A1-6BC2-412B-BE36-CC715ED8DD41");
+                var languagePreferences = new LANGPREFERENCES3[1];
+
+                languagePreferences[0].guidLang = xamlLanguageGuid;
+
+                var textManager = await this.serviceProvider.GetServiceAsync(typeof(SVsTextManager)) as IVsTextManager4;
+
+                textManager.GetUserPreferences4(pViewPrefs: null, pLangPrefs: languagePreferences, pColorPrefs: null);
+
+                return (int)languagePreferences[0].uIndentSize;
+            }
+            catch (Exception exc)
+            {
+                this.logger.RecordException(exc);
+
+                var indent = new Microsoft.VisualStudio.Text.Editor.IndentSize();
+
+                return indent.Default;
+            }
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/DteExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/DteExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using EnvDTE;
+
+namespace RapidXamlToolkit
+{
+    public static class DteExtensions
+    {
+        public static void FormatDocument(this DTE dte, Options.Profile profile)
+        {
+            // Profile passed in to ensure the check for running this command is always performed
+            if (profile?.General.AttemptAutomaticDocumentFormatting == true)
+            {
+                dte.ExecuteCommand("Edit.FormatDocument");
+            }
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
@@ -79,6 +79,10 @@ namespace $viewns$
     InitializeComponent();
 }",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -144,6 +148,10 @@ namespace $viewns$
     InitializeComponent();
 }",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -208,6 +216,10 @@ namespace $viewns$
 {
     InitializeComponent();
 }",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
                         },
                     },
 
@@ -280,6 +292,10 @@ namespace $viewns$
     InitializeComponent();
 }",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -350,6 +366,10 @@ namespace $viewns$
     InitializeComponent();
 }",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -416,6 +436,10 @@ namespace $viewns$
     InitializeComponent();
 }",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -478,6 +502,10 @@ End Namespace
                             DefaultCodeBehindConstructor = @"Public Sub New()
     Me.InitializeComponent()
 End Sub",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
                         },
                     },
 
@@ -542,6 +570,10 @@ End Namespace
     Me.InitializeComponent()
 End Sub",
                         },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
                     },
 
                     new Profile
@@ -604,6 +636,10 @@ End Namespace
                             DefaultCodeBehindConstructor = @"Public Sub New()
     Me.InitializeComponent()
 End Sub",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
                         },
                     },
 
@@ -669,6 +705,10 @@ End Property",
                             DefaultCodeBehindConstructor = @"Public sub New
     InitializeComponent()
 End Sub",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
                         },
                     },
 
@@ -740,6 +780,10 @@ namespace CsXf.Views
 {
     InitializeComponent();
 }",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
                         },
                     },
                 },

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/GeneralSettings.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/GeneralSettings.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace RapidXamlToolkit.Options
+{
+    public class GeneralSettings
+    {
+        public bool AttemptAutomaticDocumentFormatting { get; set; }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/Profile.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/Profile.cs
@@ -62,6 +62,8 @@ namespace RapidXamlToolkit.Options
 
         public DatacontextSettings Datacontext { get; set; }
 
+        public GeneralSettings General { get; set; }
+
         public static Profile CreateNew()
         {
             return new Profile

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/ProfileConfigControl.xaml
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/ProfileConfigControl.xaml
@@ -169,6 +169,22 @@
                     <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Datacontext.DefaultCodeBehindConstructor, Mode=TwoWay}" Margin="0,4,0,0" />
                 </Grid>
             </TabItem>
+            <TabItem Header="General">
+
+                <Grid Margin="4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,4,4,4" Text="{x:Static strings:StringRes.Options_AttemptAutomaticDocumentFormatting}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding General.AttemptAutomaticDocumentFormatting, Mode=TwoWay}" Margin="0,4" />
+                </Grid>
+            </TabItem>
         </TabControl>
 
         <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Content="{x:Static strings:StringRes.Options_ButtonOk}" Click="OkClicked" Width="70" HorizontalAlignment="Right" Margin="0,8,0,0" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/ProfileConfigControl.xaml
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/ProfileConfigControl.xaml
@@ -169,7 +169,7 @@
                     <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Datacontext.DefaultCodeBehindConstructor, Mode=TwoWay}" Margin="0,4,0,0" />
                 </Grid>
             </TabItem>
-            <TabItem Header="General">
+            <TabItem Header="{x:Static strings:StringRes.Options_GeneralHeader}">
 
                 <Grid Margin="4">
                     <Grid.ColumnDefinitions>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Commands\SetDataContextCommandLogic.cs" />
     <Compile Include="Commands\VisualStudioAbstraction.cs" />
     <Compile Include="Commands\WindowsFileSystem.cs" />
+    <Compile Include="DteExtensions.cs" />
     <Compile Include="ITypeSymbolExtensions.cs" />
     <Compile Include="Analyzers\VisualBasicAnalyzer.cs" />
     <Compile Include="Commands\CreateViewCommand.cs" />
@@ -98,6 +99,7 @@
     <Compile Include="Options\ConfiguredSettings.cs" />
     <Compile Include="Options\ConfiguredSettings.Default.cs" />
     <Compile Include="Options\DatacontextSettings.cs" />
+    <Compile Include="Options\GeneralSettings.cs" />
     <Compile Include="Options\ICanClose.cs" />
     <Compile Include="Options\Mapping.cs" />
     <Compile Include="Options\Profile.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -392,64 +392,68 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Editor.15.6.27740\lib\net46\Microsoft.VisualStudio.Editor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.ImageCatalog, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.ImageCatalog.15.8.28010\lib\net45\Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.0.26201\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.8.28010\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.3.26930\lib\net20\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.3.25408\lib\net20\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.LanguageServices, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.LanguageServices.2.7.0\lib\net46\Microsoft.VisualStudio.LanguageServices.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6071\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Package.LanguageService.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Package.LanguageService.15.0.15.8.28010\lib\net45\Microsoft.VisualStudio.Package.LanguageService.15.0.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.RemoteControl, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.RemoteControl.14.0.262-masterA5CACE98\lib\net45\Microsoft.VisualStudio.RemoteControl.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.26201\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.15.8.28010\lib\net45\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.0.26201\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.8.28010\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6072\lib\net11\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30320\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30319\lib\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61031\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61030\lib\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30111\lib\net20\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30110\lib\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.26929\lib\net20\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>
-      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime.15.0.26929\lib\net20\Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime.15.6.27413\lib\net20\Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30729\lib\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30730\lib\net11\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Telemetry, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Telemetry.15.3.789-masterCC863119\lib\net45\Microsoft.VisualStudio.Telemetry.dll</HintPath>
@@ -471,19 +475,24 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6071\lib\net11\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.11.0.11.0.61032\lib\net20\Microsoft.VisualStudio.TextManager.Interop.11.0.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.12.0.12.0.30112\lib\net20\Microsoft.VisualStudio.TextManager.Interop.12.0.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.3.23\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.8.168\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.8.28010\lib\net46\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Utilities.Internal.14.0.72-masterF9EB1D39\lib\net45\Microsoft.VisualStudio.Utilities.Internal.dll</HintPath>
@@ -499,6 +508,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -550,6 +562,7 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
@@ -717,7 +730,7 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.7.7\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.18\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.0-beta006\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.0-beta006\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
@@ -738,20 +751,20 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.18\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.18\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.16\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.16\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.6.170\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Import Project="..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets" Condition="Exists('..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.18\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.18\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.16\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.16\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -619,6 +619,24 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempt Automatic Document Formatting.
+        /// </summary>
+        public static string Options_AttemptAutomaticDocumentFormatting {
+            get {
+                return ResourceManager.GetString("Options_AttemptAutomaticDocumentFormatting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trigger Visual Studio&apos;s automatic document formatting after modifying a document.
+        /// </summary>
+        public static string Options_AttemptAutomaticDocumentFormattingDescription {
+            get {
+                return ResourceManager.GetString("Options_AttemptAutomaticDocumentFormattingDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
         public static string Options_ButtonAdd {
@@ -840,6 +858,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Options_FallbackOutputDescription {
             get {
                 return ResourceManager.GetString("Options_FallbackOutputDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        public static string Options_GeneralHeader {
+            get {
+                return ResourceManager.GetString("Options_GeneralHeader", resourceCulture);
             }
         }
         

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -598,4 +598,13 @@
     <value>Rapid XAML Toolkit</value>
     <comment>Name used in vsixlangpack</comment>
   </data>
+  <data name="Options_AttemptAutomaticDocumentFormatting" xml:space="preserve">
+    <value>Attempt Automatic Document Formatting</value>
+  </data>
+  <data name="Options_AttemptAutomaticDocumentFormattingDescription" xml:space="preserve">
+    <value>Trigger Visual Studio's automatic document formatting after modifying a document</value>
+  </data>
+  <data name="Options_GeneralHeader" xml:space="preserve">
+    <value>General</value>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -598,4 +598,13 @@
     <value>Rapid XAML Toolkit</value>
     <comment>Name used in vsixlangpack</comment>
   </data>
+  <data name="Options_AttemptAutomaticDocumentFormatting" xml:space="preserve">
+    <value>Attempt Automatic Document Formatting</value>
+  </data>
+  <data name="Options_AttemptAutomaticDocumentFormattingDescription" xml:space="preserve">
+    <value>Trigger Visual Studio's automatic document formatting after modifying a document</value>
+  </data>
+  <data name="Options_GeneralHeader" xml:space="preserve">
+    <value>General</value>
+  </data>
 </root>

--- a/RapidXAML.VSIX/RapidXamlToolkit/app.config
+++ b/RapidXAML.VSIX/RapidXamlToolkit/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -45,6 +45,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RapidXAML.VSIX/RapidXamlToolkit/packages.config
+++ b/RapidXAML.VSIX/RapidXamlToolkit/packages.config
@@ -15,36 +15,43 @@
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.6.27413" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.27740" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Editor" version="15.6.27740" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.25408" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.ImageCatalog" version="15.8.28010" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.8.28010" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.26930" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.LanguageServices" version="2.7.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6071" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Package.LanguageService.15.0" version="15.8.28010" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.RemoteControl" version="14.0.262-masterA5CACE98" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.7.7" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.10" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30110" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="14.3.25407" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.16" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.8.28010" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.8.28010" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6072" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30320" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61031" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30111" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="14.3.26929" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" version="15.0.26929" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime" version="15.6.27413" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50728" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30730" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Telemetry" version="15.3.789-masterCC863119" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.6.27740" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.27740" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.6.27740" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.27740" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.3.23" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.7.18" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6071" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.11.0" version="11.0.61032" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30112" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50728" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.8.168" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.168" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.8.28010" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Utilities.Internal" version="14.0.72-masterF9EB1D39" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.6.170" targetFramework="net461" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
+  <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
This PR relates to Issue #62

**Description**  
All generated XAML is now formatted across multiple lines and indented based on VS configuration.
Additionally, attempt to invoke built-in document formatting as part of other changes made by commands.
