### PR TITLE
Support generation of XAML in a RelativePanel

### DIFF
--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpClassTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Analysis/GetCSharpClassTests.cs
@@ -1760,6 +1760,171 @@ namespace OtherNamespace
             this.PositionAtStarShouldProduceExpectedUsingAdditonalFiles(codeFile1, expected, nestedListProfile, codeFile2, codeFile3);
         }
 
+        [TestMethod]
+        public void Check_RelativePanel_RepXName_MiddleAttribute()
+        {
+            var relPanelProfile = new Profile
+            {
+                Name = "RelativePanelProfile",
+                ClassGrouping = "RelativePanel",
+                FallbackOutput = "<TextBlock x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" Text=\"FB_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                },
+            };
+
+            var code = @"
+namespace tests
+{
+    class Class100 ☆
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<RelativePanel>"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property1TextBlock\" Text=\"FB_Property1\" />"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property2TextBlock\" RelativePanel.Below=\"Property1TextBlock\" Text=\"FB_Property2\" />"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property3TextBlock\" RelativePanel.Below=\"Property2TextBlock\" Text=\"FB_Property3\" />"
+         + Environment.NewLine + "</RelativePanel>";
+
+            var expected = new AnalyzerOutput
+            {
+                Name = "Class100",
+                Output = expectedOutput,
+                OutputType = AnalyzerOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, relPanelProfile);
+        }
+
+        [TestMethod]
+        public void Check_RelativePanel_RepXName_LastAttribute()
+        {
+            var relPanelProfile = new Profile
+            {
+                Name = "RelativePanelProfile",
+                ClassGrouping = "RelativePanel",
+                FallbackOutput = "<TextBlock Text=\"FB_$name$\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\"/>",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                },
+            };
+
+            var code = @"
+namespace tests
+{
+    class Class100 ☆
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            // XML Formatting will add the space before the closing tag even though it's not in the output above
+            var expectedOutput = "<RelativePanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_Property1\" x:Name=\"Property1TextBlock\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_Property2\" x:Name=\"Property2TextBlock\" RelativePanel.Below=\"Property1TextBlock\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FB_Property3\" x:Name=\"Property3TextBlock\" RelativePanel.Below=\"Property2TextBlock\" />"
+         + Environment.NewLine + "</RelativePanel>";
+
+            var expected = new AnalyzerOutput
+            {
+                Name = "Class100",
+                Output = expectedOutput,
+                OutputType = AnalyzerOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, relPanelProfile);
+        }
+
+        [TestMethod]
+        public void Check_RelativePanel_RepXName_LastAttributeNotSelfClosingTag()
+        {
+            var relPanelProfile = new Profile
+            {
+                Name = "RelativePanelProfile",
+                ClassGrouping = "RelativePanel",
+                FallbackOutput = "<TextBlock x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\">FB_$name$</TextBlock>",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                },
+            };
+
+            var code = @"
+namespace tests
+{
+    class Class100 ☆
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<RelativePanel>"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property1TextBlock\">FB_Property1</TextBlock>"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property2TextBlock\" RelativePanel.Below=\"Property1TextBlock\">FB_Property2</TextBlock>"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property3TextBlock\" RelativePanel.Below=\"Property2TextBlock\">FB_Property3</TextBlock>"
+         + Environment.NewLine + "</RelativePanel>";
+
+            var expected = new AnalyzerOutput
+            {
+                Name = "Class100",
+                Output = expectedOutput,
+                OutputType = AnalyzerOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, relPanelProfile);
+        }
+
+        [TestMethod]
+        public void Check_RelativePanel_RepXNameNotInAttribute()
+        {
+            // This will output invalid XAML but testing replacement of $rexname$
+            var relPanelProfile = new Profile
+            {
+                Name = "RelativePanelProfile",
+                ClassGrouping = "RelativePanel",
+                FallbackOutput = "<TextBlock x:Name=\"$xname$\" Text=\"FB_$name$\" /><X$repxname$ />",  // Added X before placeholder so generated XAML is valid
+                Mappings = new ObservableCollection<Mapping>
+                {
+                },
+            };
+
+            var code = @"
+namespace tests
+{
+    class Class100 ☆
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<RelativePanel>"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property1TextBlock\" Text=\"FB_Property1\" />"
+         + Environment.NewLine + "    <X />"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property2TextBlock\" Text=\"FB_Property2\" />"
+         + Environment.NewLine + "    <XProperty1TextBlock />"
+         + Environment.NewLine + "    <TextBlock x:Name=\"Property3TextBlock\" Text=\"FB_Property3\" />"
+         + Environment.NewLine + "    <XProperty2TextBlock />"
+         + Environment.NewLine + "</RelativePanel>";
+
+            var expected = new AnalyzerOutput
+            {
+                Name = "Class100",
+                Output = expectedOutput,
+                OutputType = AnalyzerOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, relPanelProfile);
+        }
+
         private void ClassNotFoundTest(string code)
         {
             var expected = AnalyzerOutput.Empty;

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/DefaultConfigurationTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/DefaultConfigurationTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 
@@ -77,6 +78,89 @@ namespace RapidXamlToolkit.Tests.Options
                 foreach (var mapping in profile.Mappings)
                 {
                     Assert.IsTrue(mapping.Output.IsValidXamlOutput(), $"Invalid output: {mapping.Output}");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EnsureOnlyValidPlaceholdersInDefaultConfig()
+        {
+            var defSet = ConfiguredSettings.GetDefaultSettings();
+            var apv = new AllowedPlaceholderValidator();
+
+            foreach (var profile in defSet.Profiles)
+            {
+                var checkResult = apv.ContainsOnlyValidPlaceholders(typeof(Profile), nameof(Profile.FallbackOutput), profile.FallbackOutput);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(Profile.FallbackOutput)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(Profile), nameof(Profile.SubPropertyOutput), profile.SubPropertyOutput);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(Profile.SubPropertyOutput)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(Profile), nameof(Profile.EnumMemberOutput), profile.EnumMemberOutput);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(Profile.EnumMemberOutput)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(ViewGenerationSettings), nameof(ViewGenerationSettings.CodePlaceholder), profile.ViewGeneration.CodePlaceholder);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(ViewGenerationSettings)}.{nameof(ViewGenerationSettings.CodePlaceholder)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(ViewGenerationSettings), nameof(ViewGenerationSettings.XamlPlaceholder), profile.ViewGeneration.XamlPlaceholder);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(ViewGenerationSettings)}.{nameof(ViewGenerationSettings.XamlPlaceholder)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(DatacontextSettings), nameof(DatacontextSettings.XamlPageAttribute), profile.Datacontext.XamlPageAttribute);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(DatacontextSettings)}.{nameof(DatacontextSettings.XamlPageAttribute)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(DatacontextSettings), nameof(DatacontextSettings.CodeBehindPageContent), profile.Datacontext.CodeBehindPageContent);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(DatacontextSettings)}.{nameof(DatacontextSettings.CodeBehindPageContent)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(DatacontextSettings), nameof(DatacontextSettings.CodeBehindConstructorContent), profile.Datacontext.CodeBehindConstructorContent);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(DatacontextSettings)}.{nameof(DatacontextSettings.CodeBehindConstructorContent)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                checkResult = apv.ContainsOnlyValidPlaceholders(typeof(DatacontextSettings), nameof(DatacontextSettings.DefaultCodeBehindConstructor), profile.Datacontext.DefaultCodeBehindConstructor);
+
+                if (!checkResult.isValid)
+                {
+                    Assert.Fail($"{nameof(DatacontextSettings)}.{nameof(DatacontextSettings.DefaultCodeBehindConstructor)} in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                }
+
+                foreach (var mapping in profile.Mappings)
+                {
+                    checkResult = apv.ContainsOnlyValidPlaceholders(typeof(Mapping), nameof(Mapping.Output), mapping.Output);
+
+                    if (!checkResult.isValid)
+                    {
+                        Assert.Fail($"Mapping output in profile '{profile.Name}' contained invalid placeholder(s): {string.Join(", ", checkResult.invalidPlaceholders)}");
+                    }
                 }
             }
         }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
@@ -98,7 +98,6 @@ namespace RapidXamlToolkit.Tests
                                 }
                             }
 
-
                             errorMessage = $"Output first differs at position {i} ({FormatChar(expected[i])}-{FormatChar(actual[i])}).";
 
                             if (actual.Contains(Environment.NewLine))

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/StringAssert.cs
@@ -86,7 +86,20 @@ namespace RapidXamlToolkit.Tests
                     {
                         if (expected[i] != actual[i])
                         {
-                            errorMessage = $"Output first differs at position {i} ({expected[i]}-{actual[i]}).";
+                            string FormatChar(char c)
+                            {
+                                if (string.IsNullOrWhiteSpace(c.ToString()))
+                                {
+                                    return $"chr({(int)c})";
+                                }
+                                else
+                                {
+                                    return c.ToString();
+                                }
+                            }
+
+
+                            errorMessage = $"Output first differs at position {i} ({FormatChar(expected[i])}-{FormatChar(actual[i])}).";
 
                             if (actual.Contains(Environment.NewLine))
                             {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/AllowedPlaceholderValidator.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/AllowedPlaceholderValidator.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace RapidXamlToolkit.Options
+{
+    public class AllowedPlaceholderValidator
+    {
+        public (bool isValid, List<string> invalidPlaceholders) ContainsOnlyValidPlaceholders(Type type, string propertyName, string output)
+        {
+            var propInfo = type.GetProperty(propertyName);
+            var attribute = propInfo.GetCustomAttribute(typeof(AllowedPlaceholdersAttribute)) as AllowedPlaceholdersAttribute;
+
+            var allowedPlaceholders = attribute.Placeholders;
+            var usedPlaceholders = output.GetPlaceholders();
+
+            var incorrectlyUsedPlaceholders = new List<string>();
+
+            foreach (var usedPlaceholder in usedPlaceholders)
+            {
+                if (!allowedPlaceholders.Contains(usedPlaceholder))
+                {
+                    incorrectlyUsedPlaceholders.Add(usedPlaceholder);
+                }
+            }
+
+            return (!incorrectlyUsedPlaceholders.Any(), incorrectlyUsedPlaceholders);
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
@@ -1252,7 +1252,7 @@ namespace CsXf.Views
                             {
                                 Type = "int|Integer",
                                 NameContains = string.Empty,
-                                Output = "<Slider Header=\"$namewithspaces$\" Minimum=\"0\" Maximum=\"100\" x:Name=\"$name$\" Value=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                Output = "<Slider Header=\"$namewithspaces$\" Minimum=\"0\" Maximum=\"100\" Value=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
                                 IfReadOnly = false,
                             },
                             new Mapping

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/ConfiguredSettings.Default.cs
@@ -225,6 +225,75 @@ namespace $viewns$
 
                     new Profile
                     {
+                        Name = "UWP C# MVVM Basic RelativePanel",
+                        ClassGrouping = "RelativePanel",
+                        FallbackOutput = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                        SubPropertyOutput = "<TextBlock Text=\"{x:Bind $name$, Mode=OneWay}\" />",
+                        EnumMemberOutput = "<RadioButton Content=\"$element$\" GroupName=\"$enumname$\" />",
+                        Mappings = MappingsForRelativePanelWithHeader(),
+                        ViewGeneration = new ViewGenerationSettings
+                        {
+                            XamlPlaceholder = @"<Page
+    x:Class=""$viewns$.$viewclass$""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:$viewns$""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+        $genxaml$
+    </Grid>
+</Page>
+",
+                            CodePlaceholder = @"using System;
+using Windows.UI.Xaml.Controls;
+using $viewmodelns$;
+
+namespace $viewns$
+{
+    public sealed partial class $viewclass$ : Page
+    {
+        public $viewmodelclass$ ViewModel { get; } = new $viewmodelclass$();
+
+        public $viewclass$()
+        {
+            InitializeComponent();
+            DataContext = ViewModel;
+        }
+    }
+}
+",
+                            XamlFileSuffix = "Page",
+                            ViewModelFileSuffix = "ViewModel",
+
+                            XamlFileDirectoryName = "Views",
+                            ViewModelDirectoryName = "ViewModels",
+
+                            AllInSameProject = true,
+
+                            XamlProjectSuffix = "n/a",
+                            ViewModelProjectSuffix = "n/a",
+                        },
+                        Datacontext = new DatacontextSettings
+                        {
+                            XamlPageAttribute = string.Empty,
+                            CodeBehindPageContent = "public $viewmodelns$.$viewmodelclass$ ViewModel { get; } = new $viewmodelns$.$viewmodelclass$();",
+                            CodeBehindConstructorContent = "DataContext = ViewModel;",
+                            DefaultCodeBehindConstructor = @"public $viewclass$()
+{
+    InitializeComponent();
+}",
+                        },
+                        General = new GeneralSettings
+                        {
+                            AttemptAutomaticDocumentFormatting = true,
+                        },
+                    },
+
+                    new Profile
+                    {
                         Name = "UWP C# MVVM Light StackPanel",
                         ClassGrouping = "StackPanel",
                         FallbackOutput = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" />",
@@ -1093,6 +1162,160 @@ namespace CsXf.Views
                                 Type = "enum",
                                 NameContains = string.Empty,
                                 Output = "<StackPanel>$members$</StackPanel>",
+                                IfReadOnly = false,
+                            },
+                        };
+        }
+
+        private static ObservableCollection<Mapping> MappingsForRelativePanelWithHeader()
+        {
+            return new ObservableCollection<Mapping>
+                        {
+                            new Mapping
+                            {
+                                Type = "String",
+                                NameContains = string.Empty,
+                                Output = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "String",
+                                NameContains = string.Empty,
+                                Output = "<TextBox Header=\"$namewithspaces$\" Text=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "phone|tel",
+                                Output = "<TextBox Header=\"$namewithspaces$\" InputScope=\"TelephoneNumber\" Text=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "email",
+                                Output = "<TextBox Header=\"$namewithspaces$\" InputScope=\"EmailNameOrAddress\" Text=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "firstname|lastname|familyname|surname|givenname",
+                                Output = "<TextBox Header=\"$namewithspaces$\" InputScope=\"PersonalFullName\" Text=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "uri|url",
+                                Output = "<TextBox Header=\"$namewithspaces$\" InputScope=\"Url\" Text=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "search",
+                                Output = "<AutoSuggestBox Header=\"$namewithspaces$\" PlaceholderText=\"Search\" QueryText=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "String",
+                                NameContains = "password|pwd",
+                                Output = "<PasswordBox Header=\"$namewithspaces$\" Password=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "string",
+                                NameContains = "uri|url",
+                                Output = "<HyperlinkButton NavigateUri=\"{x:Bind ViewModel.$name$}\" Content=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "Uri",
+                                NameContains = string.Empty,
+                                Output = "<HyperlinkButton NavigateUri=\"{x:Bind ViewModel.$name$}\" Content=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "int|Integer",
+                                NameContains = string.Empty,
+                                Output = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "int|Integer",
+                                NameContains = string.Empty,
+                                Output = "<Slider Header=\"$namewithspaces$\" Minimum=\"0\" Maximum=\"100\" x:Name=\"$name$\" Value=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "DateTimeOffset",
+                                NameContains = "date",
+                                Output = "<DatePicker Header=\"$namewithspaces$\" Date=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "DateTimeOffset",
+                                NameContains = string.Empty,
+                                Output = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "bool|Boolean",
+                                NameContains = string.Empty,
+                                Output = "<TextBlock Text=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = true,
+                            },
+                            new Mapping
+                            {
+                                Type = "bool|Boolean",
+                                NameContains = string.Empty,
+                                Output = "<ToggleSwitch Header=\"$namewithspaces$\" IsOn=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "bool|Boolean",
+                                NameContains = "busy|active",
+                                Output = "<ProgressRing IsActive=\"{x:Bind ViewModel.$name$, Mode=TwoWay}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "ICommand|Command|RelayCommand",
+                                NameContains = string.Empty,
+                                Output = "<Button Content=\"$name$\" Command=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\" />",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "ObservableCollection<T>|List<T>",
+                                NameContains = string.Empty,
+                                Output = "<ListView Header=\"$namewithspaces$\" ItemsSource=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\"><ListView.ItemTemplate><DataTemplate x:DataType=\"$type$\"><StackPanel>$subprops$</StackPanel></DataTemplate></ListView.ItemTemplate></ListView>",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "List<string>",
+                                NameContains = string.Empty,
+                                Output = "<ItemsControl ItemsSource=\"{x:Bind ViewModel.$name$}\" x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\"></ItemsControl>",
+                                IfReadOnly = false,
+                            },
+                            new Mapping
+                            {
+                                Type = "enum",
+                                NameContains = string.Empty,
+                                Output = "<StackPanel x:Name=\"$xname$\" RelativePanel.Below=\"$repxname$\">$members$</StackPanel>",
                                 IfReadOnly = false,
                             },
                         };

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/Mapping.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/Mapping.cs
@@ -13,7 +13,7 @@ namespace RapidXamlToolkit.Options
 
         public bool IfReadOnly { get; set; }
 
-        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.EnumMembers, Placeholder.SubProperties)]
+        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.EnumMembers, Placeholder.SubProperties, Placeholder.NoOutput, Placeholder.XName, Placeholder.RepeatingXName)]
         public string Output { get; set; }
 
         public static Mapping CreateNew()

--- a/RapidXAML.VSIX/RapidXamlToolkit/Options/Profile.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Options/Profile.cs
@@ -19,10 +19,10 @@ namespace RapidXamlToolkit.Options
 
         public string ClassGrouping { get; set; }
 
-        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger)]
+        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.NoOutput, Placeholder.XName, Placeholder.RepeatingXName)]
         public string FallbackOutput { get; set; }
 
-        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger)]
+        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.NoOutput, Placeholder.XName, Placeholder.RepeatingXName)]
         public string SubPropertyOutput { get; set; }
 
         [AllowedPlaceholders(Placeholder.EnumElement, Placeholder.EnumElementWithSpaces, Placeholder.EnumPropName)]

--- a/RapidXAML.VSIX/RapidXamlToolkit/Placeholder.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Placeholder.cs
@@ -45,6 +45,10 @@ namespace RapidXamlToolkit
 
         public const string NoOutput = "$nooutput$";
 
+        public const string XName = "$xname$";
+
+        public const string RepeatingXName = "$repxname$";
+
         private static List<string> all = null;
 
         public static List<string> All()

--- a/RapidXAML.VSIX/RapidXamlToolkit/Placeholder.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Placeholder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Windows.Documents;
 
 namespace RapidXamlToolkit
 {

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Logging\RxtLoggerWithTelemtry.cs" />
     <Compile Include="Logging\RxtOutputPane.cs" />
     <Compile Include="Options\AllowedPlaceholdersAttribute.cs" />
+    <Compile Include="Options\AllowedPlaceholderValidator.cs" />
     <Compile Include="Options\CanNotifyPropertyChanged.cs" />
     <Compile Include="Options\ConfiguredSettings.cs" />
     <Compile Include="Options\ConfiguredSettings.Default.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -247,6 +247,7 @@ namespace RapidXamlToolkit
             return -1;
         }
 
+        // TODO: add better checking of $nooutput$
         public static bool IsValidXamlOutput(this string source)
         {
             const string validText = "ValidText";
@@ -392,7 +393,7 @@ namespace RapidXamlToolkit
             return result;
         }
 
-        private static List<string> GetPlaceholders(this string source)
+        public static List<string> GetPlaceholders(this string source)
         {
             var plchldrRgx = new Regex("([$$][\\w]+[$$])");
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -378,6 +378,20 @@ namespace RapidXamlToolkit
             return result;
         }
 
+        public static string GetXamlElement(this string source)
+        {
+            var result = string.Empty;
+
+            if (source.TrimStart().StartsWith("<")
+             && source.TrimStart().Length > 3
+             && source.TrimStart().IndexOf(' ') > 0)
+            {
+                result = source.TrimStart().Substring(1, source.TrimStart().IndexOf(' ') - 1);
+            }
+
+            return result;
+        }
+
         private static List<string> GetPlaceholders(this string source)
         {
             var plchldrRgx = new Regex("([$$][\\w]+[$$])");

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -70,3 +70,5 @@ Profile settings and mappings can include placeholders. A placeholder is somethi
 - **$elementwithspaces$** Enum element. Is replaced with the name of an individual enum element and spaces are inserted between words if the name is camelCase or PascalCase.
 - **$enumname$** Enum property name. Is replaced with the name of the enum property.
 - **$nooutput$** No Output. Nothing will be included in the generated XAML when this is in the mapping output.
+- **$xname$** A generated value based on the property name and the XAML element this is used within.
+- **$repxname$** Repeat the last generated $xname$ value. If no $xname$ value has been generated, the attribute this is used within will be omitted from the output.


### PR DESCRIPTION
This PR relates to Issue #70

**Description**  
Adds new placeholders $xname$ and $repxname$ to enable useful generation of content within a RelativePanel

Enables generation of XAML like this

![image](https://user-images.githubusercontent.com/189547/48200164-32933180-e356-11e8-9164-ec5bf74b39e1.png)


Also added more tests to validate default config

