### PR TITLE
Adding Build scripts

### DIFF
--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Properties/AssemblyInfo.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Reflection;

--- a/RapidXAML.VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.*")]
+[assembly: AssemblyVersion("0.1.0.0")]
 [assembly: AssemblyFileVersion("0.1.0.0")]
 [assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs
@@ -20,7 +20,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.SolutionHasMultipleProjects, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.SolutionHasSingleProject, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.0.0.0", IconResourceID = 400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs-CZ.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.cs-CZ.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Schnelle XAML-Entwicklung (local)</CommandName>
+          <ButtonText>Schnelle XAML-Entwicklung (local)</ButtonText>
+          <MenuText>Schnelle XAML-Entwicklung (local)</MenuText>
+          <ToolTipText>Schnelle XAML-Entwicklung (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Schnelle XAML-Entwicklung (local)</CommandName>
+          <ButtonText>Schnelle XAML-Entwicklung (local)</ButtonText>
+          <MenuText>Schnelle XAML-Entwicklung (local)</MenuText>
+          <ToolTipText>Schnelle XAML-Entwicklung (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Schnelle XAML-Entwicklung (local)</CommandName>
+          <ButtonText>Schnelle XAML-Entwicklung (local)</ButtonText>
+          <MenuText>Schnelle XAML-Entwicklung (local)</MenuText>
+          <ToolTipText>Schnelle XAML-Entwicklung (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.de-DE.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Schnelle XAML-Entwicklung</CommandName>
-          <ButtonText>Schnelle XAML-Entwicklung</ButtonText>
-          <MenuText>Schnelle XAML-Entwicklung</MenuText>
-          <ToolTipText>Schnelle XAML-Entwicklung</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Schnelle XAML-Entwicklung</CommandName>
-          <ButtonText>Schnelle XAML-Entwicklung</ButtonText>
-          <MenuText>Schnelle XAML-Entwicklung</MenuText>
-          <ToolTipText>Schnelle XAML-Entwicklung</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Schnelle XAML-Entwicklung</CommandName>
-          <ButtonText>Schnelle XAML-Entwicklung</ButtonText>
-          <MenuText>Schnelle XAML-Entwicklung</MenuText>
-          <ToolTipText>Schnelle XAML-Entwicklung</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.en-US.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.en-US.vsct
@@ -47,26 +47,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML rápido (local)</CommandName>
+          <ButtonText>XAML rápido (local)</ButtonText>
+          <MenuText>XAML rápido (local)</MenuText>
+          <ToolTipText>XAML rápido (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML rápido (local)</CommandName>
+          <ButtonText>XAML rápido (local)</ButtonText>
+          <MenuText>XAML rápido (local)</MenuText>
+          <ToolTipText>XAML rápido (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML rápido (local)</CommandName>
+          <ButtonText>XAML rápido (local)</ButtonText>
+          <MenuText>XAML rápido (local)</MenuText>
+          <ToolTipText>XAML rápido (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.es-ES.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML rápido</CommandName>
-          <ButtonText>XAML rápido</ButtonText>
-          <MenuText>XAML rápido</MenuText>
-          <ToolTipText>XAML rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML rápido</CommandName>
-          <ButtonText>XAML rápido</ButtonText>
-          <MenuText>XAML rápido</MenuText>
-          <ToolTipText>XAML rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML rápido</CommandName>
-          <ButtonText>XAML rápido</ButtonText>
-          <MenuText>XAML rápido</MenuText>
-          <ToolTipText>XAML rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Développement XAML rapide</CommandName>
-          <ButtonText>Développement XAML rapide</ButtonText>
-          <MenuText>Développement XAML rapide</MenuText>
-          <ToolTipText>Développement XAML rapide</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Développement XAML rapide</CommandName>
-          <ButtonText>Développement XAML rapide</ButtonText>
-          <MenuText>Développement XAML rapide</MenuText>
-          <ToolTipText>Développement XAML rapide</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Développement XAML rapide</CommandName>
-          <ButtonText>Développement XAML rapide</ButtonText>
-          <MenuText>Développement XAML rapide</MenuText>
-          <ToolTipText>Développement XAML rapide</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.fr-FR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Développement XAML rapide (local)</CommandName>
+          <ButtonText>Développement XAML rapide (local)</ButtonText>
+          <MenuText>Développement XAML rapide (local)</MenuText>
+          <ToolTipText>Développement XAML rapide (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Développement XAML rapide (local)</CommandName>
+          <ButtonText>Développement XAML rapide (local)</ButtonText>
+          <MenuText>Développement XAML rapide (local)</MenuText>
+          <ToolTipText>Développement XAML rapide (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Développement XAML rapide (local)</CommandName>
+          <ButtonText>Développement XAML rapide (local)</ButtonText>
+          <MenuText>Développement XAML rapide (local)</MenuText>
+          <ToolTipText>Développement XAML rapide (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.it-IT.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.it-IT.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ja-JP.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ja-JP.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ko-KR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ko-KR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pl-PL.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pl-PL.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML Rápido (local)</CommandName>
+          <ButtonText>XAML Rápido (local)</ButtonText>
+          <MenuText>XAML Rápido (local)</MenuText>
+          <ToolTipText>XAML Rápido (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML Rápido (local)</CommandName>
+          <ButtonText>XAML Rápido (local)</ButtonText>
+          <MenuText>XAML Rápido (local)</MenuText>
+          <ToolTipText>XAML Rápido (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML Rápido (local)</CommandName>
+          <ButtonText>XAML Rápido (local)</ButtonText>
+          <MenuText>XAML Rápido (local)</MenuText>
+          <ToolTipText>XAML Rápido (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.pt-BR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML Rápido</CommandName>
-          <ButtonText>XAML Rápido</ButtonText>
-          <MenuText>XAML Rápido</MenuText>
-          <ToolTipText>XAML Rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML Rápido</CommandName>
-          <ButtonText>XAML Rápido</ButtonText>
-          <MenuText>XAML Rápido</MenuText>
-          <ToolTipText>XAML Rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML Rápido</CommandName>
-          <ButtonText>XAML Rápido</ButtonText>
-          <MenuText>XAML Rápido</MenuText>
-          <ToolTipText>XAML Rápido</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML для быстрого создания</CommandName>
-          <ButtonText>XAML для быстрого создания</ButtonText>
-          <MenuText>XAML для быстрого создания</MenuText>
-          <ToolTipText>XAML для быстрого создания</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML для быстрого создания</CommandName>
-          <ButtonText>XAML для быстрого создания</ButtonText>
-          <MenuText>XAML для быстрого создания</MenuText>
-          <ToolTipText>XAML для быстрого создания</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>XAML для быстрого создания</CommandName>
-          <ButtonText>XAML для быстрого создания</ButtonText>
-          <MenuText>XAML для быстрого создания</MenuText>
-          <ToolTipText>XAML для быстрого создания</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.ru-RU.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML для быстрого создания (local)</CommandName>
+          <ButtonText>XAML для быстрого создания (local)</ButtonText>
+          <MenuText>XAML для быстрого создания (local)</MenuText>
+          <ToolTipText>XAML для быстрого создания (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML для быстрого создания (local)</CommandName>
+          <ButtonText>XAML для быстрого создания (local)</ButtonText>
+          <MenuText>XAML для быстрого создания (local)</MenuText>
+          <ToolTipText>XAML для быстрого создания (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>XAML для быстрого создания (local)</CommandName>
+          <ButtonText>XAML для быстрого создания (local)</ButtonText>
+          <MenuText>XAML для быстрого создания (local)</MenuText>
+          <ToolTipText>XAML для быстрого создания (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Hızlı XAML</CommandName>
-          <ButtonText>Hızlı XAML</ButtonText>
-          <MenuText>Hızlı XAML</MenuText>
-          <ToolTipText>Hızlı XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Hızlı XAML</CommandName>
-          <ButtonText>Hızlı XAML</ButtonText>
-          <MenuText>Hızlı XAML</MenuText>
-          <ToolTipText>Hızlı XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Hızlı XAML</CommandName>
-          <ButtonText>Hızlı XAML</ButtonText>
-          <MenuText>Hızlı XAML</MenuText>
-          <ToolTipText>Hızlı XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.tr-TR.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Hızlı XAML (local)</CommandName>
+          <ButtonText>Hızlı XAML (local)</ButtonText>
+          <MenuText>Hızlı XAML (local)</MenuText>
+          <ToolTipText>Hızlı XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Hızlı XAML (local)</CommandName>
+          <ButtonText>Hızlı XAML (local)</ButtonText>
+          <MenuText>Hızlı XAML (local)</MenuText>
+          <ToolTipText>Hızlı XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>Hızlı XAML (local)</CommandName>
+          <ButtonText>Hızlı XAML (local)</ButtonText>
+          <MenuText>Hızlı XAML (local)</MenuText>
+          <ToolTipText>Hızlı XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>快速 XAML</CommandName>
-          <ButtonText>快速 XAML</ButtonText>
-          <MenuText>快速 XAML</MenuText>
-          <ToolTipText>快速 XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>快速 XAML</CommandName>
-          <ButtonText>快速 XAML</ButtonText>
-          <MenuText>快速 XAML</MenuText>
-          <ToolTipText>快速 XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>快速 XAML</CommandName>
-          <ButtonText>快速 XAML</ButtonText>
-          <MenuText>快速 XAML</MenuText>
-          <ToolTipText>快速 XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-CN.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>快速 XAML (local)</CommandName>
+          <ButtonText>快速 XAML (local)</ButtonText>
+          <MenuText>快速 XAML (local)</MenuText>
+          <ToolTipText>快速 XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>快速 XAML (local)</CommandName>
+          <ButtonText>快速 XAML (local)</ButtonText>
+          <MenuText>快速 XAML (local)</MenuText>
+          <ToolTipText>快速 XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML (local)</CommandName>
-          <ButtonText>Rapid XAML (local)</ButtonText>
-          <MenuText>Rapid XAML (local)</MenuText>
-          <ToolTipText>Rapid XAML (local)</ToolTipText>
+          <CommandName>快速 XAML (local)</CommandName>
+          <ButtonText>快速 XAML (local)</ButtonText>
+          <MenuText>快速 XAML (local)</MenuText>
+          <ToolTipText>快速 XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-TW.vsct
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlPackage.zh-TW.vsct
@@ -40,26 +40,26 @@
     <Menus>
       <Menu guid="guidRapidXamlPackageCmdSet" id="CodeContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="SolutionContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
       <Menu guid="guidRapidXamlPackageCmdSet" id="XamlContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Rapid XAML</CommandName>
-          <ButtonText>Rapid XAML</ButtonText>
-          <MenuText>Rapid XAML</MenuText>
-          <ToolTipText>Rapid XAML</ToolTipText>
+          <CommandName>Rapid XAML (local)</CommandName>
+          <ButtonText>Rapid XAML (local)</ButtonText>
+          <MenuText>Rapid XAML (local)</MenuText>
+          <ToolTipText>Rapid XAML (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/RapidXAML.VSIX/RapidXamlToolkit/cs-CZ/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/cs-CZ/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Sada nástrojů Rapid XAML</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Nástroje pro urychlení vývoje aplikací XAML</LocalizedDescription>
   <License>..\License\EULA.cs-CZ.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/cs-CZ/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/cs-CZ/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Sada nástrojů Rapid XAML (local)</LocalizedName>
   <LocalizedDescription>Nástroje pro urychlení vývoje aplikací XAML</LocalizedDescription>
   <License>..\License\EULA.cs-CZ.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/de-DE/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/de-DE/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Toolkit für schnelle XAML-Entwicklung (local)</LocalizedName>
   <LocalizedDescription>Tools zum Beschleunigen der XAML-App-Entwicklung</LocalizedDescription>
   <License>..\License\EULA.de-DE.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/de-DE/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/de-DE/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Toolkit für schnelle XAML-Entwicklung</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Tools zum Beschleunigen der XAML-App-Entwicklung</LocalizedDescription>
   <License>..\License\EULA.de-DE.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/es-ES/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/es-ES/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Kit de herramientas XAML rápido</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Herramientas para acelerar el desarrollo de aplicaciones XAML</LocalizedDescription>
   <License>..\License\EULA.es-ES.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/es-ES/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/es-ES/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Kit de herramientas XAML rápido (local)</LocalizedName>
   <LocalizedDescription>Herramientas para acelerar el desarrollo de aplicaciones XAML</LocalizedDescription>
   <License>..\License\EULA.es-ES.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/fr-FR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/fr-FR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Kit d'outils de développement XAML rapide</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Des outils pour accélérer le développement d'application XAML</LocalizedDescription>
   <License>..\License\EULA.fr-FR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/fr-FR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/fr-FR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Kit d'outils de développement XAML rapide (local)</LocalizedName>
   <LocalizedDescription>Des outils pour accélérer le développement d'application XAML</LocalizedDescription>
   <License>..\License\EULA.fr-FR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/it-IT/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/it-IT/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Strumenti per accelerare lo sviluppo di app XAML</LocalizedDescription>
   <License>..\License\EULA.it-IT.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/ja-JP/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/ja-JP/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML ツールキット</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>XAML アプリ開発を加速するツール</LocalizedDescription>
   <License>..\License\EULA.ja-JP.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/ja-JP/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/ja-JP/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Rapid XAML ツールキット (local)</LocalizedName>
   <LocalizedDescription>XAML アプリ開発を加速するツール</LocalizedDescription>
   <License>..\License\EULA.ja-JP.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/ko-KR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/ko-KR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>XAML 앱 개발 가속화 도구</LocalizedDescription>
   <License>..\License\EULA.ko-KR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/pl-PL/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/pl-PL/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Narzędzia przyspieszające tworzenie aplikacji XAML</LocalizedDescription>
   <License>..\License\EULA.pl-PL.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/pt-BR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/pt-BR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Kit de Ferramentas de XAML Rápido (local)</LocalizedName>
   <LocalizedDescription>Ferramentas para acelerar o desenvolvimento de aplicativos XAML</LocalizedDescription>
   <License>..\License\EULA.pt-BR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/pt-BR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/pt-BR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Kit de Ferramentas de XAML Rápido</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Ferramentas para acelerar o desenvolvimento de aplicativos XAML</LocalizedDescription>
   <License>..\License\EULA.pt-BR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/ru-RU/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/ru-RU/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Набор инструментов XAML для быстрого создания</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>Инструменты для ускорения разработки приложений XAML</LocalizedDescription>
   <License>..\License\EULA.ru-RU.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/ru-RU/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/ru-RU/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Набор инструментов XAML для быстрого создания (local)</LocalizedName>
   <LocalizedDescription>Инструменты для ускорения разработки приложений XAML</LocalizedDescription>
   <License>..\License\EULA.ru-RU.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXamlToolkit.Local.25067190-b212-4873-aecf-84547ed9b962" Version="0.0.1" Language="en-US" Publisher="Microsoft Corporation" />
-        <DisplayName>Rapid XAML Toolkit (local)</DisplayName>
-        <Description xml:space="preserve">Tools to accelerate XAML app development</Description>
-        <MoreInfo>https://github.com/Microsoft/Rapid-XAML-Toolkit</MoreInfo>
-        <License>EULA.rtf</License>
-        <GettingStartedGuide>https://github.com/Microsoft/Rapid-XAML-Toolkit/tree/master/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/Microsoft/Rapid-XAML-Toolkit/releases</ReleaseNotes>
-        <Icon>Resources\RapidXamlPackage.ico</Icon>
-        <Tags>XAML UWP WPF Xamarin.Forms</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+	<Metadata>
+		<Identity Id="RapidXamlToolkit.Local.25067190-b212-4873-aecf-84547ed9b962" Version="0.0.1" Language="en-US" Publisher="Microsoft Corporation" />
+		<DisplayName>Rapid XAML Toolkit (local)</DisplayName>
+		<Description xml:space="preserve">Tools to accelerate XAML app development</Description>
+		<MoreInfo>https://github.com/Microsoft/Rapid-XAML-Toolkit</MoreInfo>
+		<License>License\EULA.rtf</License>
+		<GettingStartedGuide>https://github.com/Microsoft/Rapid-XAML-Toolkit/tree/master/docs</GettingStartedGuide>
+		<ReleaseNotes>https://github.com/Microsoft/Rapid-XAML-Toolkit/releases</ReleaseNotes>
+		<Icon>Resources\RapidXamlPackage.ico</Icon>
+		<Tags>XAML UWP WPF Xamarin.Forms</Tags>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0)" />
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+	</Dependencies>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+	</Assets>
 </PackageManifest>

--- a/RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="RapidXamlToolkit.25067190-b212-4873-aecf-84547ed9b962" Version="0.0.1" Language="en-US" Publisher="Microsoft Corporation" />
-        <DisplayName>Rapid XAML Toolkit</DisplayName>
+        <Identity Id="RapidXamlToolkit.Local.25067190-b212-4873-aecf-84547ed9b962" Version="0.0.1" Language="en-US" Publisher="Microsoft Corporation" />
+        <DisplayName>Rapid XAML Toolkit (local)</DisplayName>
         <Description xml:space="preserve">Tools to accelerate XAML app development</Description>
         <MoreInfo>https://github.com/Microsoft/Rapid-XAML-Toolkit</MoreInfo>
         <License>EULA.rtf</License>

--- a/RapidXAML.VSIX/RapidXamlToolkit/tr-TR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/tr-TR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>Hızlı XAML Araç Seti (local)</LocalizedName>
   <LocalizedDescription>XAML uygulaması geliştirmeyi hızlandıran araçlar</LocalizedDescription>
   <License>..\License\EULA.tr-TR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/tr-TR/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/tr-TR/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Hızlı XAML Araç Seti</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>XAML uygulaması geliştirmeyi hızlandıran araçlar</LocalizedDescription>
   <License>..\License\EULA.tr-TR.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/zh-CN/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/zh-CN/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>快速 XAML 工具包</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>用于加快 XAML 应用开发的工具</LocalizedDescription>
   <License>..\License\EULA.zh-CN.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/zh-CN/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/zh-CN/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
+  <LocalizedName>快速 XAML 工具包 (local)</LocalizedName>
   <LocalizedDescription>用于加快 XAML 应用开发的工具</LocalizedDescription>
   <License>..\License\EULA.zh-CN.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/RapidXAML.VSIX/RapidXamlToolkit/zh-TW/Extension.vsixlangpack
+++ b/RapidXAML.VSIX/RapidXamlToolkit/zh-TW/Extension.vsixlangpack
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VsixLanguagePack Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema-lp/2010">
-  <LocalizedName>Rapid XAML Toolkit</LocalizedName>
+  <LocalizedName>Rapid XAML Toolkit (local)</LocalizedName>
   <LocalizedDescription>加速 XAML 應用程式開發的工具</LocalizedDescription>
   <License>..\License\EULA.zh-TW.rtf</License>
   <MoreInfoUrl>https://github.com/Microsoft/Rapid-XAML-Toolkit/</MoreInfoUrl>

--- a/_build/Extension-SetIdentityAndVersion.ps1
+++ b/_build/Extension-SetIdentityAndVersion.ps1
@@ -1,4 +1,4 @@
-# THIS SCRITP WILL NEED TO BE SPLITED NEXT TIME, GETTING TO LONG.
+# THIS SCRIPT WILL NEEDS TO BE SPLIT AS IT'S GETTING TO LONG.
 [CmdletBinding()]
 Param(
   [Parameter(Mandatory=$True,Position=1)]
@@ -52,7 +52,7 @@ else{
 ## SET IDENTITY AND VERSION IN VSIX Manifest
 if($vsixIdentity){
   Write-Host
-  Write-Host "Setting Identity in VSIX manifest"
+  Write-Host "Setting Identity in VSIX manifest."
   if(Test-Path($vsixManifestFile)){
     [xml]$manifestContent = Get-Content $vsixManifestFile
     $manifestContent.PackageManifest.Metadata.Identity.Id = $vsixIdentity
@@ -69,7 +69,7 @@ if($vsixIdentity){
         $_.FullName -match "\\RapidXamlToolkit\\"
     }
     if($vsixLangPacks){ 
-      Write-Host "Applying Display Name to vsixlangpack files"
+      Write-Host "Applying Display Name to vsixlangpack files."
       foreach ($langPack in $vsixLangPacks) {
         [xml]$langContent = Get-Content $langPack
         $langContent.VsixLanguagePack.LocalizedName = $vsixDisplayName
@@ -90,7 +90,7 @@ else{
 ## REPLACE Command Guids
 if($cmdSetGuid -and $packageGuid){
   Write-Host
-  Write-Host "Setting PackageGuid and CmdSetGuid in VSCT Files"
+  Write-Host "Setting PackageGuid and CmdSetGuid in VSCT Files."
   $vsctFiles = Get-ChildItem -include "*.vsct" -recurse |  Where-Object{ 
       $_.FullName -notmatch "\\Templates\\" -and 
       $_.FullName -notmatch "\\debug\\" -and
@@ -99,7 +99,7 @@ if($cmdSetGuid -and $packageGuid){
   }
   if($vsctFiles){ 
     Write-Host
-    Write-Host "Applying guids $cmdSetGuid, $packageGuid and command name $vsixCommandMenuName to VSCT Files"
+    Write-Host "Applying guids $cmdSetGuid, $packageGuid and command name $vsixCommandMenuName to VSCT Files."
     foreach ($vsctFile in $vsctFiles) {
       $vsctFileContent = Get-Content $vsctFile
       attrib $vsctFile -r
@@ -128,7 +128,7 @@ if($cmdSetGuid -and $packageGuid){
     Write-Host "$constFile - Guid applied (PackageGuid:$packageGuid)"
   }
   else{
-     throw "BaseCommand.cs constants file not found"
+     throw "RapidXamlPackage.cs constants file not found."
   }
 
   Write-Host
@@ -145,11 +145,11 @@ if($cmdSetGuid -and $packageGuid){
     Write-Host "$constFile - Guid applied (CmdGuid:$cmdSetGuid)"
   }
   else{
-     throw "BaseCommand.cs constants file not found"
+     throw "BaseCommand.cs constants file not found."
   }
 }
 else{
-  throw "PackageGuid and CmdSetGuid are mandatory"
+  throw "PackageGuid and CmdSetGuid are mandatory."
 }
 
 
@@ -177,7 +177,7 @@ else
 }
 
 
-## APPLY VERSION RelayCommandPackage
+## APPLY VERSION RapidXamlPackage
 Write-Host
 Write-Host "Applying version to RapidXamlPackage.cs"
 $files = Get-ChildItem -include "RapidXamlPackage.cs" -Recurse #|  Where-Object{ $_.FullName -notmatch "\\Templates\\" }
@@ -194,5 +194,5 @@ if($files)
 }
 else
 {
-    Write-Warning "No relaycommandPackage found to apply version."
+    Write-Warning "No RapidXamlPackage found to apply version."
 }

--- a/_build/Extension-SetIdentityAndVersion.ps1
+++ b/_build/Extension-SetIdentityAndVersion.ps1
@@ -32,16 +32,6 @@ Param(
   [string]$targetCmdSetGuid = "8c20aab1-50b0-4523-8d9d-24d512fa8154"
 )
 
-# TODO
-$vsixManifestFile = "RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest"
-$vsixIdentity = "RapidXamlToolkit.DevNightly.25067190-b212-4873-aecf-84547ed9b962"
-$vsixDisplayName = "Rapid Xaml Toolkit (dev-nightly)"
-$buildNumber = "1.2.3.4"
-$vsixCommandMenuName = "Rapid Xaml Toolkit (dev-nightly)"
-$packageGuid = "bd81034c-4068-47ea-9983-95e652abaeb8"
-$cmdSetGuid = "343F3EAC-C533-4120-8F96-032E50A8BA18"
-
-
 
 $VersionRegex = "(\d+)\.(\d+)\.(\d+)\.(\d+)"
 

--- a/_build/Extension-SetIdentityAndVersion.ps1
+++ b/_build/Extension-SetIdentityAndVersion.ps1
@@ -1,0 +1,208 @@
+# THIS SCRITP WILL NEED TO BE SPLITED NEXT TIME, GETTING TO LONG.
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory=$True,Position=1)]
+  [string]$vsixManifestFile,
+
+  [Parameter(Mandatory=$True,Position=2)]
+  [string]$vsixIdentity,
+
+  [Parameter(Mandatory=$True,Position=3)]
+  [string]$vsixDisplayName,
+
+  [Parameter(Mandatory=$True,Position=4)]
+  [string]$buildNumber,
+
+  [Parameter(Mandatory=$True,Position=5)]
+  [string]$vsixCommandMenuName,
+
+  [Parameter(Mandatory=$True,Position=6)]
+  [string]$packageGuid,
+
+  [Parameter(Mandatory=$True,Position=7)]
+  [string]$cmdSetGuid,
+
+  [Parameter(Mandatory=$False,Position=8)]
+  [string]$targetVsixCommandMenuName = "Rapid XAML (local)",
+
+  [Parameter(Mandatory=$False,Position=9)]
+  [string]$targetPackageGuid = "c735dfc3-c416-4501-bc33-558e2aaad8c5",
+
+  [Parameter(Mandatory=$False,Position=10)]
+  [string]$targetCmdSetGuid = "8c20aab1-50b0-4523-8d9d-24d512fa8154"
+)
+
+# TODO
+$vsixManifestFile = "RapidXAML.VSIX/RapidXamlToolkit/source.extension.vsixmanifest"
+$vsixIdentity = "RapidXamlToolkit.DevNightly.25067190-b212-4873-aecf-84547ed9b962"
+$vsixDisplayName = "Rapid Xaml Toolkit (dev-nightly)"
+$buildNumber = "1.2.3.4"
+$vsixCommandMenuName = "Rapid Xaml Toolkit (dev-nightly)"
+$packageGuid = "bd81034c-4068-47ea-9983-95e652abaeb8"
+$cmdSetGuid = "343F3EAC-C533-4120-8F96-032E50A8BA18"
+
+
+
+$VersionRegex = "(\d+)\.(\d+)\.(\d+)\.(\d+)"
+
+if($buildNumber -match $VersionRegEx){
+
+  Write-Output "Parsed Date From Build: $dateFromBuildNumber"
+
+  $revision =  [int]::Parse($matches[4]).ToString()
+  
+  $versionNumber = [int]::Parse($matches[1]).ToString() + "." + [int]::Parse($matches[2]).ToString() + "." + [int]::Parse($matches[3]).ToString() + "." + $revision
+  Write-Host "Version Number" $versionNumber
+  
+}
+else{
+	throw "Build format does not match the expected pattern (buildName_w.x.y.z)"
+}
+
+## SET IDENTITY AND VERSION IN VSIX Manifest
+if($vsixIdentity){
+  Write-Host
+  Write-Host "Setting Identity in VSIX manifest"
+  if(Test-Path($vsixManifestFile)){
+    [xml]$manifestContent = Get-Content $vsixManifestFile
+    $manifestContent.PackageManifest.Metadata.Identity.Id = $vsixIdentity
+    $manifestContent.PackageManifest.Metadata.Identity.Version = $versionNumber
+    $manifestContent.PackageManifest.Metadata.DisplayName = $vsixDisplayName
+    $resolvedPath = Resolve-Path($vsixManifestFile)
+    $manifestContent.Save($resolvedPath) 
+    Write-Host "$resolvedPath - Version, Identity & DisplayName applied ($versionNumber, $vsixIdentity, $vsixDisplayName)"
+
+    $vsixLangPacks = Get-ChildItem -include "Extension.vsixlangpack" -recurse |  Where-Object{ 
+        $_.FullName -notmatch "\\Templates\\" -and 
+        $_.FullName -notmatch "\\debug\\" -and
+        $_.FullName -notmatch "\\obj\\" -and
+        $_.FullName -match "\\RapidXamlToolkit\\"
+    }
+    if($vsixLangPacks){ 
+      Write-Host "Applying Display Name to vsixlangpack files"
+      foreach ($langPack in $vsixLangPacks) {
+        [xml]$langContent = Get-Content $langPack
+        $langContent.VsixLanguagePack.LocalizedName = $vsixDisplayName
+        $langContent.Save($langPack) 
+        Write-Host "$langPack - LocalizedName applied ($vsixDisplayName)"        
+      }
+    }
+  }
+  else{
+    throw "No VSIX manifest file found."
+  }
+}
+else{
+  throw "Identity is mandatory."
+}
+
+
+## REPLACE Command Guids
+if($cmdSetGuid -and $packageGuid){
+  Write-Host
+  Write-Host "Setting PackageGuid and CmdSetGuid in VSCT Files"
+  $vsctFiles = Get-ChildItem -include "*.vsct" -recurse |  Where-Object{ 
+      $_.FullName -notmatch "\\Templates\\" -and 
+      $_.FullName -notmatch "\\debug\\" -and
+      $_.FullName -notmatch "\\obj\\" -and
+      $_.FullName -match "\\RapidXamlToolkit\\"
+  }
+  if($vsctFiles){ 
+    Write-Host
+    Write-Host "Applying guids $cmdSetGuid, $packageGuid and command name $vsixCommandMenuName to VSCT Files"
+    foreach ($vsctFile in $vsctFiles) {
+      $vsctFileContent = Get-Content $vsctFile
+      attrib $vsctFile -r
+      $replacedVsctContent = $vsctFileContent.Replace($targetPackageGuid, $packageGuid)
+      $replacedVsctContent = $replacedVsctContent.Replace($targetCmdSetGuid, $cmdSetGuid)
+      $replacedVsctContent = $replacedVsctContent.Replace($targetVsixCommandMenuName, $vsixCommandMenuName)
+      $replacedVsctContent | Out-File $vsctFile -Encoding utf8 -Force
+      Write-Host "$vsctFile - Guids applied (PackageGuid:$packageGuid, CmdGuid:$cmdSetGuid)"        
+    }
+  }
+  else{
+    throw "No VSCT files found."
+  }
+
+  Write-Host
+  Write-Host "Applying guids $packageGuid to RapidXamlPackage.cs"
+  $path = Resolve-Path $vsixManifestFile
+  $installerPath = Split-Path $path
+  $constFile = Join-Path  $installerPath "RapidXamlPackage.cs"
+  
+  if($constFile){
+    $constFileContent = Get-Content $constFile
+    attrib $constFile -r
+    $replacedConstContent = $constFileContent.Replace($targetPackageGuid, $packageGuid)
+    $replacedConstContent | Out-File $constFile -Encoding utf8 -Force
+    Write-Host "$constFile - Guid applied (PackageGuid:$packageGuid)"
+  }
+  else{
+     throw "BaseCommand.cs constants file not found"
+  }
+
+  Write-Host
+  Write-Host "Applying guids $cmdSetGuid to BaseCommand.cs"
+  $path = Resolve-Path $vsixManifestFile
+  $installerPath = Split-Path $path
+  $constFile = Join-Path  $installerPath "Commands\BaseCommand.cs"
+  
+  if($constFile){
+    $constFileContent = Get-Content $constFile
+    attrib $constFile -r
+    $replacedConstContent = $constFileContent.Replace($targetCmdSetGuid, $cmdSetGuid)
+    $replacedConstContent | Out-File $constFile -Encoding utf8 -Force
+    Write-Host "$constFile - Guid applied (CmdGuid:$cmdSetGuid)"
+  }
+  else{
+     throw "BaseCommand.cs constants file not found"
+  }
+}
+else{
+  throw "PackageGuid and CmdSetGuid are mandatory"
+}
+
+
+## APPLY VERSION TO ASSEMBLY FILES (AssemblyVersion and AssemblyFileVersion)
+Write-Host
+Write-Host "Applying version to AssemblyInfo Files in matching the path pattern '$codePathPattern'" 
+$files = Get-ChildItem -include "*AssemblyInfo.cs" -Recurse #|  Where-Object{ $_.FullName -notmatch "\\Templates\\" }
+if($files)
+{
+    Write-Host "Will apply $versionNumber to $($files.count) files."
+
+    $assemblyVersionRegEx = "\(""$VersionRegex""\)" 
+    $assemblyVersionReplacement = "(""$versionNumber"")"
+
+    foreach ($file in $files) {
+        $filecontent = Get-Content($file)
+        attrib $file -r
+        $filecontent -replace $assemblyVersionRegEx, $assemblyVersionReplacement | Out-File $file utf8
+        Write-Host "$file - version applied"
+    }
+}
+else
+{
+    Write-Warning "No files found to apply version."
+}
+
+
+## APPLY VERSION RelayCommandPackage
+Write-Host
+Write-Host "Applying version to RapidXamlPackage.cs"
+$files = Get-ChildItem -include "RapidXamlPackage.cs" -Recurse #|  Where-Object{ $_.FullName -notmatch "\\Templates\\" }
+if($files)
+{
+    Write-Host "Will apply $versionNumber to $($files.count) files."
+
+    foreach ($file in $files) {
+        $filecontent = Get-Content($file)
+        attrib $file -r
+        $filecontent -replace $VersionRegex, $versionNumber | Out-File $file utf8
+        Write-Host "$file - version applied"
+    }
+}
+else
+{
+    Write-Warning "No relaycommandPackage found to apply version."
+}


### PR DESCRIPTION
- Script for dev.version.create build that creates a dev-nightly version for rapid XAML toolkit.
- Changed command name to Rapid XAML (local) to allow distinguish versions when installed side by side
- Fixed path to EULA
