### PR TITLE
Parser API simplification

### DIFF
--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewCSharpTests.cs
@@ -41,7 +41,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.csproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs");
 
@@ -108,7 +108,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.csproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs");
 
@@ -180,7 +180,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
                 NamedProject = new ProjectWrapper { Name = "App", FileName = @"C:\Test\App\App.csproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.cs");
 
@@ -247,7 +247,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
                 SemanticModel = semModel,
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.csproj" },
             };
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.cs");
 
@@ -281,7 +281,7 @@ namespace RapidXamlToolkit.Tests.CreateViews
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.csproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.cs");
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/CreateViews/CreateViewVisualBasicTests.cs
@@ -43,7 +43,7 @@ End Class",
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.vbproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb");
 
@@ -110,7 +110,7 @@ End Class",
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.vbproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb");
 
@@ -147,7 +147,7 @@ End Module",
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.vbproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\Files\TestViewModel.vb");
 
@@ -216,7 +216,7 @@ End Class",
                 ActiveProject = new ProjectWrapper() { Name = "App", FileName = @"C:\Test\App\App.vbproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App\ViewModels\TestViewModel.vb");
 
@@ -290,7 +290,7 @@ End Class",
                 NamedProject = new ProjectWrapper { Name = "App", FileName = @"C:\Test\App\App.vbproj" },
             };
 
-            var sut = new CreateViewCommandLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new CreateViewCommandLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             await sut.ExecuteAsync(@"C:\Test\App.ViewModels\TestViewModel.vb");
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerCSharpTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerCSharpTests.cs
@@ -22,7 +22,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetCSAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.cs", 8);
 
@@ -44,7 +44,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetCSAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.cs", 8);
 
@@ -68,7 +68,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetCSAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.cs", 8);
 
@@ -94,7 +94,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetCSAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.cs", 8);
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerLogicTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerLogicTests.cs
@@ -12,17 +12,6 @@ namespace RapidXamlToolkit.Tests.DragDrop
     public class DropHandlerLogicTests : DropHandlerTestsBase
     {
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException), "profile")]
-        public void CheckConstructorRequiredParam_Profile()
-        {
-            var fileContents = " // Just a comment";
-
-            (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
-
-            var sut = new DropHandlerLogic(null, DefaultTestLogger.Create(), vsa);
-        }
-
-        [TestMethod]
         [ExpectedException(typeof(ArgumentNullException), "logger")]
         public void CheckConstructorRequiredParam_Logger()
         {
@@ -32,7 +21,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, null, vsa);
+            var sut = new DropHandlerLogic(null, vsa);
         }
 
         [TestMethod]
@@ -41,7 +30,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
         {
             var profile = TestProfile.CreateEmpty();
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), null);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), null);
         }
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerVisualBasicTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerVisualBasicTests.cs
@@ -22,7 +22,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 
@@ -43,7 +43,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 
@@ -66,7 +66,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 
@@ -89,7 +89,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 
@@ -112,7 +112,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 
@@ -137,7 +137,7 @@ namespace RapidXamlToolkit.Tests.DragDrop
 
             (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
-            var sut = new DropHandlerLogic(profile, DefaultTestLogger.Create(), vsa, fs);
+            var sut = new DropHandlerLogic(DefaultTestLogger.Create(), vsa, fs, profile);
 
             var actual = await sut.ExecuteAsync("C:\\Tests\\SomeFile.vb", 8);
 

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
@@ -77,7 +77,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetsNonFilteredOutputIfNameDoesntMatch()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "string", "MyProperty", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("string", "MyProperty", isReadOnly: false);
 
             Assert.AreEqual(ReadWriteStringOutput.Replace("$name$", "MyProperty"), result);
         }
@@ -85,7 +86,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void ReadWritePropertyIsIdentified()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "string", "AnotherProperty", true);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("string", "AnotherProperty", isReadOnly: true);
 
             Assert.AreEqual(ReadonlyStringOutput.Replace("$name$", "AnotherProperty"), result);
         }
@@ -93,7 +95,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void SingleNameContainsIsIdentified()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "int", "number1", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("int", "number1", isReadOnly: false);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -101,7 +104,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void MultipleNameContainsIsIdentified()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "string", "EnteredPassword", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("string", "EnteredPassword", isReadOnly: false);
 
             Assert.AreEqual(ReadWritePasswordStringOutput.Replace("$name$", "EnteredPassword"), result);
         }
@@ -109,7 +113,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void ReadOnlyTakesPriorityOverContains()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "string", "EnteredPwd", true);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("string", "EnteredPwd", isReadOnly: true);
 
             Assert.AreEqual(ReadonlyStringOutput.Replace("$name$", "EnteredPwd"), result);
         }
@@ -117,7 +122,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void TypeNameIsCaseInsensitive()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "INT", "number1", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("INT", "number1", isReadOnly: false);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -125,7 +131,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void NameContainsIsCaseInsensitive()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "int", "Number1", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("int", "Number1", isReadOnly: false);
 
             Assert.AreEqual(ReadWriteNumberIntOutput, result);
         }
@@ -133,7 +140,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void NoNameContainsIsIdentified()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "int", "numero2", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("int", "numero2", isReadOnly: false);
 
             Assert.AreEqual(ReadWriteIntOutput, result);
         }
@@ -141,7 +149,8 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetFallbackIfTypeNotMapped()
         {
-            var result = CodeParserBase.GetPropertyOutput(this.testProfile, "bool", "IsAdmin", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, this.testProfile);
+            var result = cpb.GetPropertyOutput("bool", "IsAdmin", isReadOnly: false);
 
             Assert.AreEqual(FallbackOutput, result);
         }
@@ -167,7 +176,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = CodeParserBase.GetPropertyOutput(gridProfile, StringPropertyName, "MyProperty", false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, gridProfile);
+            var result = cpb.GetPropertyOutput(StringPropertyName, "MyProperty", false);
 
             var expected = "<TextBlock Text=\"MyProperty\" Grid.Row=\"1\" />" + Environment.NewLine +
                            "<TextBlock Text=\"MyProperty\" Grid.Row=\"2\" />";
@@ -195,7 +205,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = CodeParserBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: true);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, readonlyProfile);
+            var result = cpb.GetPropertyOutput(StringPropertyName, "MyProperty", isReadOnly: true);
 
             Assert.AreEqual("<ReadAndWrite />", result);
         }
@@ -220,7 +231,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = CodeParserBase.GetPropertyOutput(readonlyProfile, StringPropertyName, "MyProperty", isReadOnly: false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, readonlyProfile);
+            var result = cpb.GetPropertyOutput(StringPropertyName, "MyProperty", isReadOnly: false);
 
             Assert.AreEqual("<Fallback />", result);
         }
@@ -301,7 +313,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = CodeParserBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, wildcardGenericsProfile);
+            var result = cpb.GetPropertyOutput("List<string>", "MyProperty", isReadOnly: false);
 
             Assert.AreEqual("<Wildcard />", result);
         }
@@ -333,7 +346,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 },
             };
 
-            var result = CodeParserBase.GetPropertyOutput(wildcardGenericsProfile, "List<string>", "MyProperty", isReadOnly: false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, wildcardGenericsProfile);
+            var result = cpb.GetPropertyOutput("List<string>", "MyProperty", isReadOnly: false);
 
             Assert.AreEqual("<ListOfStrings />", result);
         }
@@ -350,7 +364,8 @@ namespace RapidXamlToolkit.Tests.Formatting
                 Output = "$namewithspaces$",
             });
 
-            var result = CodeParserBase.GetPropertyOutput(profile, "string", "MyProperty", isReadOnly: false);
+            var cpb = new CodeParserBase(DefaultTestLogger.Create(), 4, profile);
+            var result = cpb.GetPropertyOutput("string", "MyProperty", isReadOnly: false);
 
             Assert.AreEqual("My Property", result);
         }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/AllowedPlaceholderValidatorTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Options/AllowedPlaceholderValidatorTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
-using System.Linq;
 
 namespace RapidXamlToolkit.Tests.Options
 {

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/CSharpTestsBase.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/CSharpTestsBase.cs
@@ -4,7 +4,7 @@
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     public class CSharpTestsBase : StarsRepresentCaretInDocsTests, IStarsRepresentCaretInDocsTests
     {

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpArrayTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpClassTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpNullableTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpPropertiesTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpSelectionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpSelectionTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpSelectionTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpStructsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpStructsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetCSharpStructsTests : CSharpTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicArrayTests : VisualBasicTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicClassTests : VisualBasicTestsBase
@@ -1503,7 +1503,7 @@ End Namespace";
         public void CanGetIdenitifierFromModuleBlockSyntax()
         {
             var code = @"
-Public Module Order
+Public Module Or☆der
         Public Property OrderId As Integer
         Private Property OrderPlacedDateTime As DateTime
         Public Property OrderDescription As String
@@ -1512,11 +1512,19 @@ End Module";
 
             var mbs = syntaxTree.GetRoot().ChildNodes().FirstOrDefault(n => n is ModuleBlockSyntax);
 
-            var actual = VisualBasicParser.GetIdentifier(mbs);
+            var expectedXaml = "<StackPanel>"
+       + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"OrderId\" Value=\"{x:Bind OrderId, Mode=TwoWay}\" />"
+       + Environment.NewLine + "    <TextBox Text=\"{x:Bind OrderDescription, Mode=TwoWay}\" />"
+       + Environment.NewLine + "</StackPanel>";
 
-            var expected = "Order";
+            var expected = new ParserOutput
+            {
+                Name = "Order",
+                Output = expectedXaml,
+                OutputType = ParserOutputType.Class,
+            };
 
-            Assert.AreEqual(expected, actual);
+            this.PositionAtStarShouldProduceExpected(code, expected);
         }
 
         private void FindNoPropertiesInClass(string code)

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicNullableTests : VisualBasicTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicPropertiesTests : VisualBasicTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicSelectionTests : VisualBasicTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicStructsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicStructsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
     public class GetVisualBasicStructsTests : VisualBasicTestsBase

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/IStarsRepresentCaretInDocsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/IStarsRepresentCaretInDocsTests.cs
@@ -4,7 +4,7 @@
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     public interface IStarsRepresentCaretInDocsTests
     {

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     public abstract class StarsRepresentCaretInDocsTests
     {
@@ -186,10 +186,10 @@ namespace RapidXamlToolkit.Tests.Analysis
             for (var pos = startPos; pos < endPos; pos++)
             {
                 var indent = new TestVisualStudioAbstraction().XamlIndent;
-                var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                        : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+                var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent, profileOverload) as IDocumentParser
+                                        : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-                var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+                var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos);
 
                 Assert.AreEqual(expected.OutputType, actual.OutputType, $"Failure at {pos} ({startPos}-{endPos})");
                 Assert.AreEqual(expected.Name, actual.Name, $"Failure at {pos} ({startPos}-{endPos})");
@@ -216,10 +216,10 @@ namespace RapidXamlToolkit.Tests.Analysis
                                     : VisualBasicCompilation.Create(string.Empty).AddSyntaxTrees(syntaxTree).GetSemanticModel(syntaxTree, true);
 
             var indent = new TestVisualStudioAbstraction().XamlIndent;
-            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent, profileOverload) as IDocumentParser
+                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos);
 
             this.AssertOutput(expected, actual);
         }
@@ -252,10 +252,10 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var indent = new TestVisualStudioAbstraction().XamlIndent;
 
-            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent, profileOverload) as IDocumentParser
+                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos);
 
             this.AssertOutput(expected, actual);
         }
@@ -290,10 +290,10 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var indent = new TestVisualStudioAbstraction().XamlIndent;
 
-            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent, profileOverload) as IDocumentParser
+                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos, profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos);
 
             this.AssertOutput(expected, actual);
         }
@@ -328,10 +328,10 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var indent = new TestVisualStudioAbstraction().XamlIndent;
 
-            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent,profileOverload) as IDocumentParser
+                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos,  profileOverload);
+            var actual = analyzer.GetSingleItemOutput(syntaxTree.GetRoot(), semModel, pos);
 
             this.AssertOutput(expected, actual);
         }
@@ -352,10 +352,10 @@ namespace RapidXamlToolkit.Tests.Analysis
 
             var indent = new TestVisualStudioAbstraction().XamlIndent;
 
-            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent) as IDocumentParser
-                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent);
+            var analyzer = isCSharp ? new CSharpParser(DefaultTestLogger.Create(), indent, profileOverload) as IDocumentParser
+                                    : new VisualBasicParser(DefaultTestLogger.Create(), indent, profileOverload);
 
-            var actual = analyzer.GetSelectionOutput(syntaxTree.GetRoot(), semModel, startPos, endPos,  profileOverload);
+            var actual = analyzer.GetSelectionOutput(syntaxTree.GetRoot(), semModel, startPos, endPos);
 
             this.AssertOutput(expected, actual);
         }

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/VisualBasicTestsBase.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/VisualBasicTestsBase.cs
@@ -4,7 +4,7 @@
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;
 
-namespace RapidXamlToolkit.Tests.Analysis
+namespace RapidXamlToolkit.Tests.Parsers
 {
     public class VisualBasicTestsBase : StarsRepresentCaretInDocsTests, IStarsRepresentCaretInDocsTests
     {

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommand.cs
@@ -165,9 +165,7 @@ namespace RapidXamlToolkit.Commands
                 this.Logger?.RecordInfo(StringRes.Info_AttemptingToCreateView);
                 var dte = await this.ServiceProvider.GetServiceAsync(typeof(DTE)) as DTE;
 
-                var profile = CodeParserBase.GetSettings().GetActiveProfile();
-
-                var logic = new CreateViewCommandLogic(profile, this.Logger, new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte));
+                var logic = new CreateViewCommandLogic(this.Logger, new VisualStudioAbstraction(this.Logger, this.ServiceProvider, dte));
 
                 await logic.ExecuteAsync(this.SelectedFileName);
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
@@ -14,13 +14,15 @@ namespace RapidXamlToolkit.Commands
     {
         private readonly ILogger logger;
         private readonly IFileSystemAbstraction fileSystem;
+        private readonly Profile profileOverride;
         private readonly IVisualStudioAbstraction vs;
 
-        public CreateViewCommandLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
+        public CreateViewCommandLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null, Profile profileOverride = null)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
+            this.profileOverride = profileOverride;
         }
 
         public bool CreateView { get; private set; }
@@ -51,11 +53,11 @@ namespace RapidXamlToolkit.Commands
             switch (fileExt)
             {
                 case ".cs":
-                    analyzer = new CSharpParser(this.logger, indent);
+                    analyzer = new CSharpParser(this.logger, indent, this.profileOverride);
                     codeBehindExt = ((CSharpParser)analyzer).FileExtension;
                     break;
                 case ".vb":
-                    analyzer = new VisualBasicParser(this.logger, indent);
+                    analyzer = new VisualBasicParser(this.logger, indent, this.profileOverride);
                     codeBehindExt = ((VisualBasicParser)analyzer).FileExtension;
                     break;
             }

--- a/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Commands/CreateViewCommandLogic.cs
@@ -12,14 +12,12 @@ namespace RapidXamlToolkit.Commands
 {
     public class CreateViewCommandLogic
     {
-        private readonly Profile profile;
         private readonly ILogger logger;
         private readonly IFileSystemAbstraction fileSystem;
         private readonly IVisualStudioAbstraction vs;
 
-        public CreateViewCommandLogic(Profile profile, ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
+        public CreateViewCommandLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
         {
-            this.profile = profile ?? throw new ArgumentNullException(nameof(profile));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
@@ -85,9 +83,9 @@ namespace RapidXamlToolkit.Commands
 
                 var syntaxRoot = await syntaxTree.GetRootAsync();
 
-                var analyzerOutput = ((IDocumentParser)analyzer).GetSingleItemOutput(syntaxRoot, semModel, cursorPos, this.profile);
+                var analyzerOutput = ((IDocumentParser)analyzer).GetSingleItemOutput(syntaxRoot, semModel, cursorPos);
 
-                var config = this.profile.ViewGeneration;
+                var config = analyzer.Profile.ViewGeneration;
 
                 var vmClassName = analyzerOutput.Name;
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
@@ -15,13 +15,15 @@ namespace RapidXamlToolkit.DragDrop
     {
         private readonly ILogger logger;
         private readonly IFileSystemAbstraction fileSystem;
+        private readonly Profile profileOverride;
         private readonly IVisualStudioAbstraction vs;
 
-        public DropHandlerLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
+        public DropHandlerLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null, Profile profileOverride = null)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
+            this.profileOverride = profileOverride;
         }
 
         public async Task<string> ExecuteAsync(string draggedFilename, int insertLineLength)
@@ -31,8 +33,8 @@ namespace RapidXamlToolkit.DragDrop
 
             var indent = await this.vs.GetXamlIndentAsync();
 
-            var analyzer = fileExt == ".cs" ? new CSharpParser(this.logger, indent)
-                                            : (IDocumentParser)new VisualBasicParser(this.logger, indent);
+            var analyzer = fileExt == ".cs" ? new CSharpParser(this.logger, indent, this.profileOverride)
+                                            : (IDocumentParser)new VisualBasicParser(this.logger, indent, this.profileOverride);
 
             // IndexOf is allowing for "class " in C# and "Class " in VB
             var cursorPos = fileContents.IndexOf("lass ");

--- a/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
@@ -13,14 +13,12 @@ namespace RapidXamlToolkit.DragDrop
 {
     public class DropHandlerLogic
     {
-        private readonly Profile profile;
         private readonly ILogger logger;
         private readonly IFileSystemAbstraction fileSystem;
         private readonly IVisualStudioAbstraction vs;
 
-        public DropHandlerLogic(Profile profile, ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
+        public DropHandlerLogic(ILogger logger, IVisualStudioAbstraction vs, IFileSystemAbstraction fileSystem = null)
         {
-            this.profile = profile ?? throw new ArgumentNullException(nameof(profile));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
@@ -55,7 +53,7 @@ namespace RapidXamlToolkit.DragDrop
 
             var treeRoot = await syntaxTree.GetRootAsync();
 
-            var analyzerOutput = analyzer.GetSingleItemOutput(treeRoot, semModel, cursorPos, this.profile);
+            var analyzerOutput = analyzer.GetSingleItemOutput(treeRoot, semModel, cursorPos);
 
             string textOutput = analyzerOutput.Output;
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/RapidXamlDropHandler.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/DragDrop/RapidXamlDropHandler.cs
@@ -40,9 +40,7 @@ namespace RapidXamlToolkit.DragDrop
 
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var profile = CodeParserBase.GetSettings().GetActiveProfile();
-
-                var logic = new DropHandlerLogic(profile, this.logger, this.vs, this.fileSystem);
+                var logic = new DropHandlerLogic(this.logger, this.vs, this.fileSystem);
 
                 var textOutput = await logic.ExecuteAsync(this.draggedFilename, insertLineLength);
 

--- a/RapidXAML.VSIX/RapidXamlToolkit/Parsers/IDocumentParser.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Parsers/IDocumentParser.cs
@@ -8,8 +8,8 @@ namespace RapidXamlToolkit.Parsers
 {
     public interface IDocumentParser
     {
-        ParserOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition, Profile profileOverload = null);
+        ParserOutput GetSingleItemOutput(SyntaxNode documentRoot, SemanticModel semModel, int caretPosition);
 
-        ParserOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd, Profile profileOverload = null);
+        ParserOutput GetSelectionOutput(SyntaxNode documentRoot, SemanticModel semModel, int selStart, int selEnd);
     }
 }


### PR DESCRIPTION
Pass profile overload to Parser constructor
removes the need to pass the profile between methods so much and allows removing of some overloads - simplifying code and testing.