### PR TITLE
POC: use DataAnnotations in XAML Gen

### DIFF
--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+    [TestClass]
+    public class GetCSharpAttributesTests : CSharpTestsBase
+    {
+        private readonly Profile maxLengthProfile = new Profile
+        {
+            Name = "maxLength=Profile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBlock Text=\"$name$\" $att:MaxLength:MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile maxLengthAttributeProfile = new Profile
+        {
+            Name = "maxLengthAttributeProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBlock Text=\"$name$\" $att:MaxLengthAttribute:MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile rangeProfile = new Profile
+        {
+            Name = "rangeAttributeProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<Slider Name=\"$name$\"$att:Range: Minimum=\"[1]\"$$att:Range: Maximum=\"[2]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile displayNameProfile = new Profile
+        {
+            Name = "displayNameProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBox Text=\"$name$\" $att:Display: Header=\"[Name]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile displayNameAndMaxLengthProfile = new Profile
+        {
+            Name = "displayNameAndMaxLengthProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBox Text=\"$name$\"$att:Display: Header=\"[Name]\"$$att:MaxLength: MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        [TestMethod]
+        public void Display_NameEqualsParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [Display(Name = ShortName)]
+        public ☆string Name { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
+        }
+
+        [TestMethod]
+        public void Display_NameColonParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [Display(Name: ShortName)]
+        public ☆string Name { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
+        }
+
+        [TestMethod]
+        public void DisplayAndMaxLength_SeparateAttributes()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [Display(Name: ShortName)]
+        [MaxLength(50)]
+        public ☆string Name { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
+        }
+
+        [TestMethod]
+        public void DisplayAndMaxLength_SingleAttribute()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [Display(Name: ShortName), MaxLength(50)]
+        public ☆string Name { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLength_SingleNumericParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [MaxLength(50)]
+        public ☆string Name { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLengthAttribute_SingleNumericParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [MaxLengthAttribute(50)]
+        public string Name☆ { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLength_AttributeIncludedInProfile_SingleNumericParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [MaxLength(50)]
+        public string Name☆ { get; set; }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthAttributeProfile);
+        }
+
+        [TestMethod]
+        public void RangeAttribute_MultipleNumericParams()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        [Range(1, 5)]
+        public int ☆Rating { get; set; }
+    }
+}";
+
+            var expectedOutput = "<Slider Name=\"Rating\" Minimum=\"1\" Maximum=\"5\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Rating",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
+        }
+
+        [TestMethod]
+        public void RangeAttribute_InProfileButNotOnProperty_NoOutput()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        public int ☆Rating { get; set; }
+    }
+}";
+
+            var expectedOutput = "<Slider Name=\"Rating\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Rating",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
+        }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributesTests.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributesTests.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+    [TestClass]
+    public class GetVisualBasicAttributesTests : VisualBasicTestsBase
+    {
+        private readonly Profile maxLengthProfile = new Profile
+        {
+            Name = "maxLength=Profile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBlock Text=\"$name$\" $att:MaxLength:MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile maxLengthAttributeProfile = new Profile
+        {
+            Name = "maxLengthAttributeProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBlock Text=\"$name$\" $att:MaxLengthAttribute:MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile rangeProfile = new Profile
+        {
+            Name = "rangeAttributeProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<Slider Name=\"$name$\"$att:Range: Minimum=\"[1]\"$$att:Range: Maximum=\"[2]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile displayNameProfile = new Profile
+        {
+            Name = "displayNameProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBox Text=\"$name$\" $att:Display: Header=\"[Name]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        private readonly Profile displayNameAndMaxLengthProfile = new Profile
+        {
+            Name = "displayNameAndMaxLengthProfile",
+            ClassGrouping = "Grid",
+            FallbackOutput = "<TextBox Text=\"$name$\"$att:Display: Header=\"[Name]\"$$att:MaxLength: MaxLength=\"[1]\"$ />",
+            SubPropertyOutput = string.Empty,
+            EnumMemberOutput = string.Empty,
+            Mappings = new ObservableCollection<Mapping>
+            {
+            },
+        };
+
+        [TestMethod]
+        public void Display_NamedParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <Display(Name:= ShortName)>
+        Public Property ☆Name As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
+        }
+
+        [TestMethod]
+        public void DisplayAndMaxLength_SeparateAttributes()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <Display(Name:= ShortName)>
+        <MaxLength(50)>
+        Public Property ☆Name As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
+        }
+
+        [TestMethod]
+        public void DisplayAndMaxLength_SingleAttribute()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <Display(Name:= ShortName), MaxLength(50)>
+        Public Property ☆Name As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBox Text=\"Name\" Header=\"ShortName\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLength_SingleNumericParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <MaxLength(50)>
+        Public Property ☆Name As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLengthAttribute_SingleNumericParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <MaxLengthAttribute(50)>
+        Public Property ☆Name As String
+
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
+        }
+
+        [TestMethod]
+        public void MaxLength_AttributeIncludedInProfile_SingleNumericParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <MaxLength(50)>
+        Public Property ☆Name As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthAttributeProfile);
+        }
+
+        [TestMethod]
+        public void RangeAttribute_MultipleNumericParams()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        <Range(1, 5)>
+        Public Property ☆Rating As Integer
+    End Class
+End Namespace";
+
+            var expectedOutput = "<Slider Name=\"Rating\" Minimum=\"1\" Maximum=\"5\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Rating",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
+        }
+
+        [TestMethod]
+        public void RangeAttribute_InProfileButNotOnProperty_NoOutput()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        Public Property ☆Rating As Integer
+    End Class
+End Namespace";
+
+            var expectedOutput = "<Slider Name=\"Rating\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Rating",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
+        }
+
+        [TestMethod]
+        public void MaxLengthAttribute_SingleNumericParam_PropertyBlock()
+        {
+            var code = @"
+Namespace tests
+    Class Class
+
+        Private _name As String
+
+        <MaxLengthAttribute(50)>
+        Public Property Name☆ As String
+            Get
+                Return _name
+            End Get
+
+            Set(ByVal value As String)
+                _name = value
+            End Set
+        End Property
+
+    End Class
+End Namespace";
+
+            var expectedOutput = "<TextBlock Text=\"Name\" MaxLength=\"50\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Name",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
+        }
+
+    }
+}
+
+

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Grid\MissingDefinitionsTests.cs" />
     <Compile Include="Misc\MiscRealWorldTests.cs" />
     <Compile Include="Parsers\CSharpTestsBase.cs" />
+    <Compile Include="Parsers\GetCSharpAttributesTests.cs" />
     <Compile Include="Parsers\GetVisualBasicArrayTests.cs" />
     <Compile Include="Parsers\GetCSharpClassTests.cs" />
     <Compile Include="Parsers\GetCSharpArrayTests.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Parsers\GetVisualBasicArrayTests.cs" />
     <Compile Include="Parsers\GetCSharpClassTests.cs" />
     <Compile Include="Parsers\GetCSharpArrayTests.cs" />
+    <Compile Include="Parsers\GetVisualBasicAttributesTests.cs" />
     <Compile Include="Parsers\GetVisualBasicNullableTests.cs" />
     <Compile Include="Parsers\GetCSharpPropertiesTests.cs" />
     <Compile Include="Parsers\GetCSharpSelectionTests.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/Parsers/AttributeArgumentDetails.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Parsers/AttributeArgumentDetails.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace RapidXamlToolkit.Parsers
+{
+    public class AttributeArgumentDetails
+    {
+        public int Index { get; set; }
+
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Parsers/AttributeDetails.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Parsers/AttributeDetails.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace RapidXamlToolkit.Parsers
+{
+    public class AttributeDetails
+    {
+        public string Name { get; set; }
+
+        public List<AttributeArgumentDetails> Arguments { get; set; } = new List<AttributeArgumentDetails>();
+    }
+}

--- a/RapidXAML.VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -360,6 +360,48 @@ namespace RapidXamlToolkit.Parsers
                 IsReadOnly = propIsReadOnly ?? false,
             };
 
+            foreach (var attribList in propertyDeclaration.AttributeLists)
+            {
+                foreach (var attrib in attribList.Attributes)
+                {
+                    var att = new AttributeDetails
+                    {
+                        Name = attrib.Name.ToString(),
+                    };
+
+                    var count = 1;
+                    foreach (var arg in attrib.ArgumentList.Arguments)
+                    {
+                        string name = null;
+                        string value = null;
+
+                        if (arg?.NameColon != null)
+                        {
+                            name = arg.NameColon.Name.ToString();
+                            value = ((arg.NameColon.Parent as AttributeArgumentSyntax).Expression as IdentifierNameSyntax).Identifier.Value.ToString();
+                        }
+                        else if (arg?.NameEquals != null)
+                        {
+                            name = arg.NameEquals.Name.ToString();
+                            value = ((arg.NameEquals.Parent as AttributeArgumentSyntax).Expression as IdentifierNameSyntax).Identifier.Value.ToString();
+                        }
+                        else
+                        {
+                            value = arg.ToString();
+                        }
+
+                        att.Arguments.Add(new AttributeArgumentDetails
+                        {
+                            Index = count++,
+                            Name = name,
+                            Value = value,
+                        });
+                    }
+
+                    pd.Attributes.Add(att);
+                }
+            }
+
             Logger?.RecordInfo(StringRes.Info_IdentifiedPropertySummary.WithParams(pd.Name, pd.PropertyType, pd.IsReadOnly));
 
             ITypeSymbol typeSymbol = this.GetTypeSymbol(semModel, propertyDeclaration, pd);

--- a/RapidXAML.VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace RapidXamlToolkit.Parsers
@@ -14,5 +15,7 @@ namespace RapidXamlToolkit.Parsers
         public bool IsReadOnly { get; set; }
 
         public ITypeSymbol Symbol { get; set; }
+
+        public List<AttributeDetails> Attributes { get; set; } = new List<AttributeDetails>();
     }
 }

--- a/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/RapidXAML.VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -67,6 +67,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Commands\MoveAllHardCodedStringsToResourceFileCommand.cs" />
+    <Compile Include="Parsers\AttributeArgumentDetails.cs" />
+    <Compile Include="Parsers\AttributeDetails.cs" />
     <Compile Include="VisualStudioIntegration\IVisualStudioTextManipulation.cs" />
     <Compile Include="VisualStudioIntegration\VisualStudioTextManipulation.cs" />
     <Compile Include="ErrorList\ErrorRow.cs" />

--- a/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/RapidXAML.VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -433,5 +433,25 @@ namespace RapidXamlToolkit
 
             return result;
         }
+
+        public static string GetBetween(this string source, string start, string end)
+        {
+            if (string.IsNullOrEmpty(start) || string.IsNullOrEmpty(end))
+            {
+                return string.Empty;
+            }
+
+            var startPos = source.IndexOf(start);
+            var endPos = source.IndexOf(end, startPos + start.Length);
+
+            if (startPos > -1 && endPos > -1 && endPos > startPos)
+            {
+                return source.Substring(startPos + start.Length, endPos - startPos - start.Length);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
     }
 }


### PR DESCRIPTION
Exploratory work for #57 
Allows use of attributes in the underlying generation logic and has tests to prove it works but the ability to configure this in settings/UI is not yet supported.