### PR TITLE
Change build environment to VS2019

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# It's mine I tell you. Mine, all mine! <maniacal-laugh />
+*       @mrlacey

--- a/VSIX/OptionsEmulator/App.config
+++ b/VSIX/OptionsEmulator/App.config
@@ -9,6 +9,22 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/VSIX/OptionsEmulator/App.config
+++ b/VSIX/OptionsEmulator/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
   <runtime>
     <assemblyBinding>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VSIX/OptionsEmulator/OptionsEmulator.csproj
+++ b/VSIX/OptionsEmulator/OptionsEmulator.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/VSIX/OptionsEmulator/OptionsEmulator.csproj
+++ b/VSIX/OptionsEmulator/OptionsEmulator.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>OptionsEmulator</RootNamespace>
     <AssemblyName>OptionsEmulator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -98,7 +99,9 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.0-beta006</Version>
+      <Version>1.1.118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/VSIX/OptionsEmulator/OptionsEmulator.csproj
+++ b/VSIX/OptionsEmulator/OptionsEmulator.csproj
@@ -34,7 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>SA0001</NoWarn>
+    <NoWarn>SA0001,NU1605,NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>OptionsEmulator.App</StartupObject>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/GlobalSuppressions.cs
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/GlobalSuppressions.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
-// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Documentation of code in test projects is not required.")]

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -29,6 +29,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\RapidXamlToolkit.Tests.Manual.xml</DocumentationFile>
+    <NoWarn>NU1605,NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -49,7 +51,9 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="..\RapidXamlToolkit.Tests\GlobalSuppressions.cs">
+      <Link>GlobalSuppressions.cs</Link>
+    </Compile>
     <Compile Include="Options\WindowContentsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSettings.cs" />
@@ -67,6 +71,15 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
+      <Version>3.3.0-beta3-19409-05</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
+      <Version>3.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
       <Version>16.1.89</Version>
     </PackageReference>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -39,6 +39,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>NU1605,NU1608</NoWarn>
+    <DocumentationFile>bin\Release\RapidXamlToolkit.Tests.Manual.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RapidXamlToolkit.Tests.Manual</RootNamespace>
     <AssemblyName>RapidXamlToolkit.Tests.Manual</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -67,14 +67,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
+      <Version>16.1.89</Version>
+    </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsTestHelpers">
-      <Version>0.1.15</Version>
+      <Version>0.2.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.0-beta006</Version>
+      <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/ParseRealDocumentsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/ParseRealDocumentsTests.cs
@@ -41,14 +41,14 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
             {
                 var snapshot = new RapidXamlToolkit.Tests.FakeTextSnapshot();
 
-                XamlElementExtractor.Parse(snapshot, text, RapidXamlDocument.GetAllProcessors(), result.Tags);
+                XamlElementExtractor.Parse(filePath, snapshot, text, RapidXamlDocument.GetAllProcessors(), result.Tags);
 
                 Debug.WriteLine($"Found {result.Tags.Count} taggable issues in '{filePath}'.");
 
                 if (result.Tags.Count > 0)
                 {
                     // if (result.Tags.Count > 10)
-                    if (result.Tags.OfType<RapidXamlWarningTag>().Any())
+                    if (result.Tags.OfType<RapidXamlDisplayedTag>().Any())
                     {
                         Debugger.Break();
                     }

--- a/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/TestDocsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/TestDocsTests.cs
@@ -21,7 +21,7 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
 
             var snapshot = new RapidXamlToolkit.Tests.FakeTextSnapshot();
 
-            XamlElementExtractor.Parse(snapshot, text, RapidXamlDocument.GetAllProcessors(), result.Tags);
+            XamlElementExtractor.Parse("Generic.xaml", snapshot, text, RapidXamlDocument.GetAllProcessors(), result.Tags);
 
             Assert.AreEqual(0, result.Tags.OfType<MissingRowDefinitionTag>().Count());
             Assert.AreEqual(0, result.Tags.OfType<MissingColumnDefinitionTag>().Count());

--- a/VSIX/RapidXamlToolkit.Tests.Manual/app.config
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/app.config
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/app.config
@@ -3,9 +3,24 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+  </startup>
+</configuration>

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
@@ -237,9 +237,13 @@ namespace RapidXamlToolkit.Tests.Parsers
             var language = isCSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic;
             var fileExt = isCSharp ? "cs" : "vb";
 
-            var solution = new AdhocWorkspace().CurrentSolution
-                                               .AddProject(projectId, "MyProject", "MyProject", language)
-                                               .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            Solution solution;
+            using (var adhocWorkspace = new AdhocWorkspace())
+            {
+                solution = adhocWorkspace.CurrentSolution
+                                         .AddProject(projectId, "MyProject", "MyProject", language)
+                                         .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            }
 
             foreach (var addCode in additionalCode)
             {
@@ -273,9 +277,13 @@ namespace RapidXamlToolkit.Tests.Parsers
             var language = isCSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic;
             var fileExt = isCSharp ? "cs" : "vb";
 
-            var solution = new AdhocWorkspace().CurrentSolution
-                                               .AddProject(projectId, "MyProject", "MyProject", language)
-                                               .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            Solution solution;
+            using (var adhocWorkspace = new AdhocWorkspace())
+            {
+                solution = adhocWorkspace.CurrentSolution
+                                         .AddProject(projectId, "MyProject", "MyProject", language)
+                                         .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            }
 
             foreach (var addRef in additionalReferences)
             {
@@ -311,9 +319,13 @@ namespace RapidXamlToolkit.Tests.Parsers
             var language = isCSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic;
             var fileExt = isCSharp ? "cs" : "vb";
 
-            var solution = new AdhocWorkspace().CurrentSolution
-                                               .AddProject(projectId, "MyProject", "MyProject", language)
-                                               .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            Solution solution;
+            using (var adhocWorkspace = new AdhocWorkspace())
+            {
+                solution = adhocWorkspace.CurrentSolution
+                                         .AddProject(projectId, "MyProject", "MyProject", language)
+                                         .AddDocument(documentId, $"MyFile.{fileExt}", actualCode);
+            }
 
             foreach (var libPath in additionalLibraryPaths)
             {

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\RapidXamlToolkit.Tests.xml</DocumentationFile>
-    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <NoWarn>,1573,1591,1712,NU1605,NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RapidXamlToolkit.Tests</RootNamespace>
     <AssemblyName>RapidXamlToolkit.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RapidXamlToolkit.Tests.xml</DocumentationFile>
-    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <NoWarn>,1573,1591,1712,8356</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -138,12 +138,6 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\RapidXamlToolkit\RapidXamlToolkit.csproj">
-      <Project>{053a3048-276a-49ed-bd34-9c3ab1273a26}</Project>
-      <Name>RapidXamlToolkit</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Assets\TestLibrary.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -152,16 +146,19 @@
     <PackageReference Include="ApiAnalysis.SimpleJsonAnalyzer.vsixuse">
       <Version>1.8.0</Version>
     </PackageReference>
-    <PackageReference Include="Madskristensen.VisualStudio.SDK">
-      <Version>15.8.81-pre</Version>
+    <PackageReference Include="Microsoft.CodeAnalysis">
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <Version>2.6.3</Version>
+      <Version>2.9.4</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.9.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>16.0.200</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.4.0</Version>
@@ -170,12 +167,17 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.0-beta006</Version>
+      <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\RapidXamlToolkit\RapidXamlToolkit.csproj">
+      <Project>{053a3048-276a-49ed-bd34-9c3ab1273a26}</Project>
+      <Name>RapidXamlToolkit</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RapidXamlToolkit.Tests.xml</DocumentationFile>
-    <NoWarn>,1573,1591,1712,8356</NoWarn>
+    <NoWarn>,1573,1591,1712,8356,NU1605,NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -154,8 +154,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
+      <Version>3.3.0-beta3-19409-05</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>16.0.200</Version>

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/TagListSuppressionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/TagListSuppressionTests.cs
@@ -15,9 +15,9 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
     {
         private const string TestFileName = "testFile.xaml";
 
-        private string element = "<MenuFlyoutItem Text=\"menu1\" />";
+        private readonly string element = "<MenuFlyoutItem Text=\"menu1\" />";
 
-        private IRapidXamlAdornmentTag tag = new HardCodedStringTag(new Span(1, 14), new FakeTextSnapshot(), TestFileName, 1, 1, Elements.MenuFlyoutItem, Attributes.Text);
+        private readonly IRapidXamlAdornmentTag tag = new HardCodedStringTag(new Span(1, 14), new FakeTextSnapshot(), TestFileName, 1, 1, Elements.MenuFlyoutItem, Attributes.Text);
 
         [TestMethod]
         public void Tag_AddedIf_NoSuppressions()
@@ -48,15 +48,16 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT123",
-                FileName = TestFileName,
-                ElementIdentifier = "",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT123",
+                    FileName = TestFileName,
+                    ElementIdentifier = "",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 
@@ -69,15 +70,16 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "XYZ=123",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "XYZ=123",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 
@@ -90,22 +92,23 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "XYZ=123",
-                Reason = "For testing",
-            });
-            suppressions.Add(new TagSuppression
-            {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "XYZ=456",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "XYZ=123",
+                    Reason = "For testing",
+                },
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "XYZ=456",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 
@@ -118,15 +121,16 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 
@@ -139,22 +143,23 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "XYZ987",
-                Reason = "For testing",
-            });
-            suppressions.Add(new TagSuppression
-            {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "XYZ987",
+                    Reason = "For testing",
+                },
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 
@@ -167,15 +172,16 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var tags = new TagList();
 
-            var suppressions = new List<TagSuppression>();
-
-            suppressions.Add(new TagSuppression
+            var suppressions = new List<TagSuppression>
             {
-                TagErrorCode = "RXT200",
-                FileName = TestFileName,
-                ElementIdentifier = "Text=\"menu1\"",
-                Reason = "For testing",
-            });
+                new TagSuppression
+                {
+                    TagErrorCode = "RXT200",
+                    FileName = TestFileName,
+                    ElementIdentifier = "Text=\"menu1\"",
+                    Reason = "For testing",
+                },
+            };
 
             var tryResult = tags.TryAdd(this.tag, this.element, suppressions);
 

--- a/VSIX/RapidXamlToolkit.Tests/app.config
+++ b/VSIX/RapidXamlToolkit.Tests/app.config
@@ -3,44 +3,20 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VSIX/RapidXamlToolkit/Commands/CopyToClipboardCommand.cs
+++ b/VSIX/RapidXamlToolkit/Commands/CopyToClipboardCommand.cs
@@ -42,7 +42,9 @@ namespace RapidXamlToolkit.Commands
             Instance = new CopyToClipboardCommand(package, commandService, logger);
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods - Allowed as called from event handler.
         private async void Execute(object sender, EventArgs e)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             try
             {

--- a/VSIX/RapidXamlToolkit/Commands/MoveAllHardCodedStringsToResourceFileCommand.cs
+++ b/VSIX/RapidXamlToolkit/Commands/MoveAllHardCodedStringsToResourceFileCommand.cs
@@ -54,7 +54,9 @@ namespace RapidXamlToolkit.Commands
             Instance = new MoveAllHardCodedStringsToResourceFileCommand(package, commandService, logger);
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods - Allowed as called from event handler.
         private async void Execute(object sender, EventArgs e)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             System.Windows.Forms.Cursor previousCursor;
 

--- a/VSIX/RapidXamlToolkit/Commands/SendToToolboxCommand.cs
+++ b/VSIX/RapidXamlToolkit/Commands/SendToToolboxCommand.cs
@@ -66,7 +66,9 @@ namespace RapidXamlToolkit.Commands
             tbs?.AddItem(tbItem, itemInfo, StringRes.UI_ToolboxGroupHeader);
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods - Allowed as called from event handler.
         private async void Execute(object sender, EventArgs e)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             try
             {

--- a/VSIX/RapidXamlToolkit/ErrorList/SinkManager.cs
+++ b/VSIX/RapidXamlToolkit/ErrorList/SinkManager.cs
@@ -12,7 +12,7 @@ namespace RapidXamlToolkit.ErrorList
     {
         private readonly ITableDataSink sink;
         private readonly TableDataSource errorList;
-        private List<TableEntriesSnapshot> snapshots = new List<TableEntriesSnapshot>();
+        private readonly List<TableEntriesSnapshot> snapshots = new List<TableEntriesSnapshot>();
 
         internal SinkManager(TableDataSource errorList, ITableDataSink sink)
         {

--- a/VSIX/RapidXamlToolkit/ErrorList/TableDataSource.cs
+++ b/VSIX/RapidXamlToolkit/ErrorList/TableDataSource.cs
@@ -16,8 +16,8 @@ namespace RapidXamlToolkit.ErrorList
 {
     public class TableDataSource : ITableDataSource
     {
+        private static readonly Dictionary<string, TableEntriesSnapshot> Snapshots = new Dictionary<string, TableEntriesSnapshot>();
         private static TableDataSource instance;
-        private static Dictionary<string, TableEntriesSnapshot> snapshots = new Dictionary<string, TableEntriesSnapshot>();
         private readonly List<SinkManager> managers = new List<SinkManager>();
 
         private TableDataSource()
@@ -53,7 +53,7 @@ namespace RapidXamlToolkit.ErrorList
             }
         }
 
-        public bool HasErrors => snapshots.Any();
+        public bool HasErrors => Snapshots.Any();
 
         public string SourceTypeIdentifier => StandardTableDataSources.ErrorTableDataSource;
 
@@ -95,7 +95,7 @@ namespace RapidXamlToolkit.ErrorList
             {
                 foreach (var manager in this.managers)
                 {
-                    manager.UpdateSink(snapshots.Values);
+                    manager.UpdateSink(Snapshots.Values);
                 }
             }
         }
@@ -107,10 +107,10 @@ namespace RapidXamlToolkit.ErrorList
                 return;
             }
 
-            result.Errors = result.Errors.Where(v => !snapshots.Any(s => s.Value.Errors.Contains(v)) && v.ErrorType != TagErrorType.Hidden).ToList();
+            result.Errors = result.Errors.Where(v => !Snapshots.Any(s => s.Value.Errors.Contains(v)) && v.ErrorType != TagErrorType.Hidden).ToList();
 
             var snapshot = new TableEntriesSnapshot(result);
-            snapshots[result.FilePath] = snapshot;
+            Snapshots[result.FilePath] = snapshot;
 
             this.UpdateAllSinks();
         }
@@ -119,10 +119,10 @@ namespace RapidXamlToolkit.ErrorList
         {
             foreach (string url in urls)
             {
-                if (url != null && snapshots.ContainsKey(url))
+                if (url != null && Snapshots.ContainsKey(url))
                 {
-                    snapshots[url].Dispose();
-                    snapshots.Remove(url);
+                    Snapshots[url].Dispose();
+                    Snapshots.Remove(url);
                 }
             }
 
@@ -139,13 +139,13 @@ namespace RapidXamlToolkit.ErrorList
 
         public void CleanAllErrors()
         {
-            foreach (string url in snapshots.Keys)
+            foreach (string url in Snapshots.Keys)
             {
-                var snapshot = snapshots[url];
+                var snapshot = Snapshots[url];
                 snapshot?.Dispose();
             }
 
-            snapshots.Clear();
+            Snapshots.Clear();
 
             lock (this.managers)
             {

--- a/VSIX/RapidXamlToolkit/ErrorList/TableDataSource.cs
+++ b/VSIX/RapidXamlToolkit/ErrorList/TableDataSource.cs
@@ -119,7 +119,7 @@ namespace RapidXamlToolkit.ErrorList
         {
             foreach (string url in urls)
             {
-                if (snapshots.ContainsKey(url))
+                if (url != null && snapshots.ContainsKey(url))
                 {
                     snapshots[url].Dispose();
                     snapshots.Remove(url);

--- a/VSIX/RapidXamlToolkit/Options/SettingsControl.xaml.cs
+++ b/VSIX/RapidXamlToolkit/Options/SettingsControl.xaml.cs
@@ -229,36 +229,37 @@ namespace RapidXamlToolkit.Options
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var openFileDialog = new System.Windows.Forms.OpenFileDialog
+                using (var openFileDialog = new System.Windows.Forms.OpenFileDialog
                 {
                     InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                     Filter = $"{StringRes.UI_ProfileFilterDescription} (*.rxprofile)|*.rxprofile",
                     Multiselect = false,
-                };
-
-                if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                })
                 {
-                    var fileContents = File.ReadAllText(openFileDialog.FileName);
-
-                    var parser = new ApiAnalysis.SimpleJsonAnalyzer();
-
-                    var parserResults = await parser.AnalyzeJsonAsync(fileContents, typeof(Profile));
-
-                    if (parserResults.Count == 1 && parserResults.First() == parser.MessageBuilder.AllGoodMessage)
+                    if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                     {
-                        var profile = Newtonsoft.Json.JsonConvert.DeserializeObject<Profile>(fileContents);
+                        var fileContents = File.ReadAllText(openFileDialog.FileName);
 
-                        this.SettingsProvider.ActualSettings.Profiles.Add(profile);
-                        this.SettingsProvider.Save();
-                        this.SettingsProvider.ActualSettings.RefreshProfilesList();
-                    }
-                    else
-                    {
-                        MessageBox.Show(
-                                        StringRes.Prompt_ImportFailedMessage.WithParams(string.Join(Environment.NewLine + "- ", parserResults)),
-                                        StringRes.Prompt_ImportFailedTitle,
-                                        MessageBoxButton.OK,
-                                        MessageBoxImage.Error);
+                        var parser = new ApiAnalysis.SimpleJsonAnalyzer();
+
+                        var parserResults = await parser.AnalyzeJsonAsync(fileContents, typeof(Profile));
+
+                        if (parserResults.Count == 1 && parserResults.First() == parser.MessageBuilder.AllGoodMessage)
+                        {
+                            var profile = Newtonsoft.Json.JsonConvert.DeserializeObject<Profile>(fileContents);
+
+                            this.SettingsProvider.ActualSettings.Profiles.Add(profile);
+                            this.SettingsProvider.Save();
+                            this.SettingsProvider.ActualSettings.RefreshProfilesList();
+                        }
+                        else
+                        {
+                            MessageBox.Show(
+                                            StringRes.Prompt_ImportFailedMessage.WithParams(string.Join(Environment.NewLine + "- ", parserResults)),
+                                            StringRes.Prompt_ImportFailedTitle,
+                                            MessageBoxButton.OK,
+                                            MessageBoxImage.Error);
+                        }
                     }
                 }
             }
@@ -285,16 +286,17 @@ namespace RapidXamlToolkit.Options
                     var selectedProfile = this.SettingsProvider.ActualSettings.Profiles[this.DisplayedProfiles.SelectedIndex];
                     var profileJson = selectedProfile.AsJson();
 
-                    var saveFileDialog = new System.Windows.Forms.SaveFileDialog
+                    using (var saveFileDialog = new System.Windows.Forms.SaveFileDialog
                     {
                         InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                         Filter = $"{StringRes.UI_ProfileFilterDescription} (*.rxprofile)|*.rxprofile",
                         FileName = $"{selectedProfile.Name}.rxprofile",
-                    };
-
-                    if (saveFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    })
                     {
-                        File.WriteAllText(saveFileDialog.FileName, profileJson);
+                        if (saveFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                        {
+                            File.WriteAllText(saveFileDialog.FileName, profileJson);
+                        }
                     }
                 }
             }

--- a/VSIX/RapidXamlToolkit/Options/SettingsControl.xaml.cs
+++ b/VSIX/RapidXamlToolkit/Options/SettingsControl.xaml.cs
@@ -216,7 +216,9 @@ namespace RapidXamlToolkit.Options
             }
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods - Allowed as called from event handler.
         private async void ImportClicked(object sender, RoutedEventArgs e)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             if (this.disabled)
             {

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -52,7 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RapidXamlToolkitExt.xml</DocumentationFile>
-    <NoWarn>,1573,1591,1712,1762</NoWarn>
+    <NoWarn>,1573,1591,1712,1762,NU1605,NU1608</NoWarn>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -408,13 +408,13 @@
     <AdditionalFiles Include="..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
     <Content Include="appsettings.json">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Key.snk" />
     <Content Include="cs-CZ\Extension.vsixlangpack" />
     <Content Include="de-DE\Extension.vsixlangpack" />
@@ -487,6 +487,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
@@ -645,7 +646,7 @@
       <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.2.1-beta4-19407-13</Version>
+      <Version>3.3.0-beta3-19409-05</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
       <Version>3.2.0</Version>
@@ -684,7 +685,7 @@
       <Version>12.0.30112</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>16.2.3073</Version>
+      <Version>16.2.3074</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -7,6 +7,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -31,7 +32,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RapidXamlToolkit</RootNamespace>
     <AssemblyName>RapidXamlToolkitExt</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -620,56 +621,80 @@
     <PackageReference Include="AvalonEdit">
       <Version>5.0.4</Version>
     </PackageReference>
-    <PackageReference Include="Madskristensen.VisualStudio.SDK">
-      <Version>15.8.81-pre</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.9.1</Version>
+      <Version>2.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis">
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <Version>2.6.3</Version>
+      <Version>2.9.4</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
+      <Version>3.2.1-beta4-19407-13</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventSource.Redist">
-      <Version>1.1.16-beta</Version>
+      <Version>2.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility">
+      <Version>16.1.89</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>2.9.0</Version>
+      <Version>3.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>16.0.200</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers">
+      <Version>16.3.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">
-      <Version>15.8.956</Version>
+      <Version>16.3.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.1.89</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
+      <Version>16.1.89</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0">
       <Version>12.0.30112</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>15.9.3039</Version>
+      <Version>16.2.3073</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.0-beta006</Version>
+      <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Reactive">
-      <Version>4.1.3</Version>
+      <Version>4.1.6</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -64,7 +64,7 @@
     <WarningLevel>4</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <DocumentationFile>bin\Release\RapidXamlToolkitExt.xml</DocumentationFile>
-    <NoWarn>,1573,1591,1712,1762</NoWarn>
+    <NoWarn>,1573,1591,1712,1762,NU1605,NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Commands\MoveAllHardCodedStringsToResourceFileCommand.cs" />

--- a/VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -377,25 +377,28 @@ namespace RapidXamlToolkit
             catch (XmlException)
             {
                 // Assume failures are due to multiple root elements
-                xtr = new XmlTextReader(new StringReader($"<wrap>{source}</wrap>"))
+                using (var xmlTextReader = new XmlTextReader(new StringReader($"<wrap>{source}</wrap>"))
                 {
                     Namespaces = false,
-                };
-
-                try
+                })
                 {
-                    doc.Load(xtr);
+                    xtr = xmlTextReader;
 
-                    wrapped = true;
-                }
-                catch (Exception exc)
-                {
-                    // The generated XAML isn't valid XML. This is useful in debugging only.
-                    // Assume the invalid XAML was intentional. If not then the mapping needs updating.
-                    System.Diagnostics.Debug.WriteLine(exc);
+                    try
+                    {
+                        doc.Load(xtr);
 
-                    // If can't process as XML then can't pad it. Just return the original.
-                    return source;
+                        wrapped = true;
+                    }
+                    catch (Exception exc)
+                    {
+                        // The generated XAML isn't valid XML. This is useful in debugging only.
+                        // Assume the invalid XAML was intentional. If not then the mapping needs updating.
+                        System.Diagnostics.Debug.WriteLine(exc);
+
+                        // If can't process as XML then can't pad it. Just return the original.
+                        return source;
+                    }
                 }
             }
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/AddEntryKeyboardAction.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/AddEntryKeyboardAction.cs
@@ -25,9 +25,10 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public static AddEntryKeyboardAction[] Create(AddEntryKeyboardTag tag, string file)
         {
-            var result = new List<AddEntryKeyboardAction>();
-
-            result.Add(new AddEntryKeyboardAction(file, tag, "Default"));
+            var result = new List<AddEntryKeyboardAction>
+            {
+                new AddEntryKeyboardAction(file, tag, "Default"),
+            };
 
             if (!string.IsNullOrWhiteSpace(tag.NonDefaultKeyboardSuggestion))
             {

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/BaseSuggestedAction.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/BaseSuggestedAction.cs
@@ -41,7 +41,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public virtual ImageMoniker IconMoniker
         {
-            get { return default(ImageMoniker); }
+            get { return default; }
         }
 
         public string InputGestureText

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/BaseSuggestedAction.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/BaseSuggestedAction.cs
@@ -70,9 +70,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public void Invoke(CancellationToken cancellationToken)
         {
+            var undoContext = ProjectHelpers.Dte2.UndoContext;
+
             try
             {
-                ProjectHelpers.Dte2.UndoContext.Open(this.DisplayText);
+                undoContext.Open(this.DisplayText);
                 this.Execute(cancellationToken);
             }
             catch (Exception exc)
@@ -81,7 +83,10 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
             }
             finally
             {
-                ProjectHelpers.Dte2.UndoContext.Close();
+                if (undoContext.IsOpen)
+                {
+                    undoContext.Close();
+                }
             }
         }
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/HardCodedStringAction.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Actions/HardCodedStringAction.cs
@@ -43,7 +43,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
                 return;
             }
 
-            var vs = (this.vstm != null) ? this.vstm : new VisualStudioTextManipulation(ProjectHelpers.Dte);
+            var vs = this.vstm ?? new VisualStudioTextManipulation(ProjectHelpers.Dte);
 
             var undo = vs.StartSingleUndoOperation(StringRes.Info_UndoContextMoveStringToResourceFile);
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/XamlElementProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/XamlElementProcessor.cs
@@ -114,6 +114,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             XamlElementExtractor.Parse(fileName, null, xaml.Substring(startPos), new List<(string element, XamlElementProcessor processor)> { (elementName, processor), }, new TagList());
 
+            if (result == null)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+
             return result;
         }
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/RapidXamlTagger.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/RapidXamlTagger.cs
@@ -11,8 +11,8 @@ namespace RapidXamlToolkit.XamlAnalysis
 {
     public class RapidXamlTagger : ITagger<IErrorTag>
     {
-        private ITextBuffer buffer;
-        private string file;
+        private readonly ITextBuffer buffer;
+        private readonly string file;
 
         public RapidXamlTagger(ITextBuffer buffer, string file)
         {

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/SuggestedActionsSource.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/SuggestedActionsSource.cs
@@ -39,6 +39,7 @@ namespace RapidXamlToolkit.XamlAnalysis
             RapidXamlDocumentCache.Add(this.file, textBuffer.CurrentSnapshot);
         }
 
+        // This is not called and so a warning (CS0067) is raised but not supressing this as expect to call this in future.
         public event EventHandler<EventArgs> SuggestedActionsChanged;
 
         // Observable event wrapper

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/SuggestedActionsSource.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/SuggestedActionsSource.cs
@@ -23,8 +23,8 @@ namespace RapidXamlToolkit.XamlAnalysis
         private readonly RxtSettings config = new RxtSettings();
         private readonly ITextView view;
         private readonly ISuggestedActionCategoryRegistryService suggestedActionCategoryRegistry;
-        private string file;
-        private IViewTagAggregatorFactoryService tagService;
+        private readonly string file;
+        private readonly IViewTagAggregatorFactoryService tagService;
 
         public SuggestedActionsSource(IViewTagAggregatorFactoryService tagService, ISuggestedActionCategoryRegistryService suggestedActionCategoryRegistry, ITextView view, ITextBuffer textBuffer, string file)
         {

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/TagList.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/TagList.cs
@@ -11,10 +11,8 @@ namespace RapidXamlToolkit.XamlAnalysis
     {
         public bool TryAdd(IRapidXamlAdornmentTag tag, string xamlElement, List<TagSuppression> suppressions)
         {
-            var displayedTag = tag as RapidXamlDisplayedTag;
-
             // Only suppress tags that might be displayed as only they have error codes
-            if (displayedTag != null)
+            if (tag is RapidXamlDisplayedTag displayedTag)
             {
                 if (suppressions != null)
                 {

--- a/VSIX/RapidXamlToolkit/app.config
+++ b/VSIX/RapidXamlToolkit/app.config
@@ -1,43 +1,47 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+        <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="15.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/VSIX/RapidXamlToolkit/app.config
+++ b/VSIX/RapidXamlToolkit/app.config
@@ -3,45 +3,24 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0"/>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0"/>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="15.0.0.0"/>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+  </startup>
+</configuration>


### PR DESCRIPTION
This moves the expected build environment to be VS2019 and adjusts references accordingly.
Integration complexities are such that a single project can't hold appropriate references for both VS15&16. Separate projects would be needed. Managing two versions is an overhead that is undesirable when current focus is getting to a preview launch.

Will create a follow up action to remove installer from attempting to act on VS2017.

Support for running the extension in VS2017 may be restored in the future, subject to demand.



