### PR TITLE
RapidXamlDisplayedTag to calculate line & column directly

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerLogicTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/DragDrop/DropHandlerLogicTests.cs
@@ -16,11 +16,9 @@ namespace RapidXamlToolkit.Tests.DragDrop
         [ExpectedException(typeof(ArgumentNullException), "logger")]
         public void CheckConstructorRequiredParam_Logger()
         {
-            var profile = TestProfile.CreateEmpty();
-
             var fileContents = " // Just a comment";
 
-            (IFileSystemAbstraction fs, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
+            (IFileSystemAbstraction _, IVisualStudioAbstraction vsa) = this.GetVbAbstractions(fileContents);
 
             var sut = new DropHandlerLogic(null, vsa);
         }
@@ -29,8 +27,6 @@ namespace RapidXamlToolkit.Tests.DragDrop
         [ExpectedException(typeof(ArgumentNullException), "vs")]
         public void CheckConstructorRequiredParam_VS()
         {
-            var profile = TestProfile.CreateEmpty();
-
             var sut = new DropHandlerLogic(DefaultTestLogger.Create(), null);
         }
     }

--- a/VSIX/RapidXamlToolkit.Tests/Grid/GridExclusionsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Grid/GridExclusionsTests.cs
@@ -30,8 +30,6 @@ namespace RapidXamlToolkit.Tests.Grid
 + Environment.NewLine + ""
 + Environment.NewLine + "    </Grid>";
 
-            var expected = new Dictionary<int, int>();
-
             this.ShouldReturnExclusionsMarkedByStars(xaml);
         }
 

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/TagListSuppressionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/TagListSuppressionTests.cs
@@ -17,7 +17,7 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
 
         private readonly string element = "<MenuFlyoutItem Text=\"menu1\" />";
 
-        private readonly IRapidXamlAdornmentTag tag = new HardCodedStringTag(new Span(1, 14), new FakeTextSnapshot(), TestFileName, 1, 1, Elements.MenuFlyoutItem, Attributes.Text);
+        private readonly IRapidXamlAdornmentTag tag = new HardCodedStringTag(new Span(1, 14), new FakeTextSnapshot(), TestFileName, Elements.MenuFlyoutItem, Attributes.Text);
 
         [TestMethod]
         public void Tag_AddedIf_NoSuppressions()

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/CheckBoxProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/CheckBoxProcessor.cs
@@ -47,9 +47,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
                 if (hasCheckedEvent && !hasuncheckedEvent)
                 {
-                    var line = snapshot.GetLineFromPosition(offset + checkedIndex);
-                    var col = offset + checkedIndex - line.Start.Position;
-                    var checkedTag = new CheckBoxCheckedAndUncheckedEventsTag(new Span(offset + checkedIndex, checkedLength), snapshot, fileName, line.LineNumber, col, checkedEventName, hasChecked: true)
+                    var checkedTag = new CheckBoxCheckedAndUncheckedEventsTag(new Span(offset + checkedIndex, checkedLength), snapshot, fileName, checkedEventName, hasChecked: true)
                     {
                         InsertPosition = offset,
                     };
@@ -59,9 +57,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
                 if (!hasCheckedEvent && hasuncheckedEvent)
                 {
-                    var line = snapshot.GetLineFromPosition(offset + uncheckedIndex);
-                    var col = offset + uncheckedIndex - line.Start.Position;
-                    var uncheckedTag = new CheckBoxCheckedAndUncheckedEventsTag(new Span(offset + uncheckedIndex, uncheckedLength), snapshot, fileName, line.LineNumber, col, uncheckedEventName, hasChecked: false)
+                    var uncheckedTag = new CheckBoxCheckedAndUncheckedEventsTag(new Span(offset + uncheckedIndex, uncheckedLength), snapshot, fileName, uncheckedEventName, hasChecked: false)
                     {
                         InsertPosition = offset,
                     };

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/EntryProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/EntryProcessor.cs
@@ -24,11 +24,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             if (!this.TryGetAttribute(xamlElement, Attributes.Keyboard, AttributeType.Inline | AttributeType.Element, out _, out _, out _, out _))
             {
-                var line = snapshot.GetLineFromPosition(offset);
-                var col = offset - line.Start.Position;
-
                 tags.TryAdd(
-                    new AddEntryKeyboardTag(new Span(offset, xamlElement.Length), snapshot, fileName, line.LineNumber, col, xamlElement)
+                    new AddEntryKeyboardTag(new Span(offset, xamlElement.Length), snapshot, fileName, xamlElement)
                     {
                         InsertPosition = offset,
                     },

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/EveryElementProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/EveryElementProcessor.cs
@@ -21,18 +21,14 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 if (!char.IsUpper(value[0]))
                 {
-                    var line = snapshot.GetLineFromPosition(offset + index);
-                    var col = offset + index - line.Start.Position;
-                    tags.TryAdd(new UidTitleCaseTag(new Span(offset + index, length), snapshot, fileName, line.LineNumber, col, value), xamlElement, suppressions);
+                    tags.TryAdd(new UidTitleCaseTag(new Span(offset + index, length), snapshot, fileName, value), xamlElement, suppressions);
                 }
             }
             else if (this.TryGetAttribute(xamlElement, Attributes.X_Uid, AttributeType.InlineOrElement, out _, out index, out length, out value))
             {
                 if (!char.IsUpper(value[0]))
                 {
-                    var line = snapshot.GetLineFromPosition(offset + index);
-                    var col = offset + index - line.Start.Position;
-                    tags.TryAdd(new UidTitleCaseTag(new Span(offset + index, length), snapshot, fileName, line.LineNumber, col, value), xamlElement, suppressions);
+                    tags.TryAdd(new UidTitleCaseTag(new Span(offset + index, length), snapshot, fileName, value), xamlElement, suppressions);
                 }
             }
 
@@ -40,18 +36,14 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 if (!char.IsUpper(value[0]))
                 {
-                    var line = snapshot.GetLineFromPosition(offset + index);
-                    var col = offset + index - line.Start.Position;
-                    tags.TryAdd(new NameTitleCaseTag(new Span(offset + index, length), snapshot, fileName, line.LineNumber, col, value), xamlElement, suppressions);
+                    tags.TryAdd(new NameTitleCaseTag(new Span(offset + index, length), snapshot, fileName, value), xamlElement, suppressions);
                 }
             }
             else if (this.TryGetAttribute(xamlElement, Attributes.X_Name, AttributeType.InlineOrElement, out _, out index, out length, out value))
             {
                 if (!char.IsUpper(value[0]))
                 {
-                    var line = snapshot.GetLineFromPosition(offset + index);
-                    var col = offset + index - line.Start.Position;
-                    tags.TryAdd(new NameTitleCaseTag(new Span(offset + index, length), snapshot, fileName, line.LineNumber, col, value), xamlElement, suppressions);
+                    tags.TryAdd(new NameTitleCaseTag(new Span(offset + index, length), snapshot, fileName, value), xamlElement, suppressions);
                 }
             }
         }

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/GridProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/GridProcessor.cs
@@ -155,9 +155,6 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 defUseOffset += nextDefUseIndex;
 
-                var line = snapshot.GetLineFromPosition(offset + defUseOffset);
-                var col = offset + defUseOffset - line.Start.Position;
-
                 if (nextDefUseIndex > endOfOpening)
                 {
                     // Get assigned value
@@ -175,9 +172,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                                 undefinedTags.Add(new MissingRowDefinitionTag(
                                     new Span(offset + defUseOffset, closePos - defUseOffset + 1),
                                     snapshot,
-                                    fileName,
-                                    line.LineNumber,
-                                    col)
+                                    fileName)
                                 {
                                     AssignedInt = assignedInt,
                                     Description = StringRes.Info_XamlAnalysisMissingRowDefinitionDescription.WithParams(assignedInt),
@@ -208,9 +203,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                                 undefinedTags.Add(new MissingColumnDefinitionTag(
                                     new Span(offset + defUseOffset, closePos - defUseOffset + 1),
                                     snapshot,
-                                    fileName,
-                                    line.LineNumber,
-                                    col)
+                                    fileName)
                                 {
                                     AssignedInt = assignedInt,
                                     Description = StringRes.Info_XamlAnalysisMissingColumnDefinitionDescription.WithParams(assignedInt),
@@ -249,9 +242,6 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 spanUseOffset += nextSpanUseIndex;
 
-                var line = snapshot.GetLineFromPosition(offset + spanUseOffset);
-                var col = offset + spanUseOffset - line.Start.Position;
-
                 if (nextSpanUseIndex > endOfOpening)
                 {
                     if (xamlElement.Substring(spanUseOffset).StartsWith(rowSpanUse))
@@ -276,9 +266,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                                 var rowTag = new RowSpanOverflowTag(
                                     new Span(offset + spanUseOffset, closePos - spanUseOffset + 1),
                                     snapshot,
-                                    fileName,
-                                    line.LineNumber,
-                                    col)
+                                    fileName)
                                 {
                                     TotalDefsRequired = assignedInt + row - 1,
                                     Description = StringRes.Info_XamlAnalysisRowSpanOverflowDescription,
@@ -314,9 +302,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                                 var colTag = new ColumnSpanOverflowTag(
                                     new Span(offset + spanUseOffset, closePos - spanUseOffset + 1),
                                     snapshot,
-                                    fileName,
-                                    line.LineNumber,
-                                    gridCol)
+                                    fileName)
                                 {
                                     TotalDefsRequired = assignedInt - 1 + gridCol,
                                     Description = StringRes.Info_XamlAnalysisColumnSpanOverflowDescription,

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/MediaElementProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/MediaElementProcessor.cs
@@ -22,10 +22,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                 return;
             }
 
-            var line = snapshot.GetLineFromPosition(offset);
-            var col = offset - line.Start.Position;
             tags.TryAdd(
-                new UseMediaPlayerElementTag(new Span(offset, xamlElement.Length), snapshot, fileName, line.LineNumber, col)
+                new UseMediaPlayerElementTag(new Span(offset, xamlElement.Length), snapshot, fileName)
                 {
                     InsertPosition = offset,
                 },

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/SelectedItemAttributeProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/SelectedItemAttributeProcessor.cs
@@ -21,8 +21,6 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 if (value.StartsWith("{") && !value.Contains("TwoWay"))
                 {
-                    var line = snapshot.GetLineFromPosition(offset);
-
                     string existingMode = null;
 
                     const string oneTime = "Mode=OneTime";
@@ -38,7 +36,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                     }
 
                     tags.TryAdd(
-                        new SelectedItemBindingModeTag(new Span(offset + index, length), snapshot, fileName, line.LineNumber, index)
+                        new SelectedItemBindingModeTag(new Span(offset + index, length), snapshot, fileName)
                         {
                             InsertPosition = offset + index,
                             ExistingBindingMode = existingMode,

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/TextBoxProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/TextBoxProcessor.cs
@@ -60,11 +60,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             if (!this.TryGetAttribute(xamlElement, Attributes.InputScope, AttributeType.Inline | AttributeType.Element, out _, out _, out _, out _))
             {
-                var line = snapshot.GetLineFromPosition(offset);
-                var col = offset - line.Start.Position;
-
                 tags.TryAdd(
-                    new AddTextBoxInputScopeTag(new Span(offset, xamlElement.Length), snapshot, fileName, line.LineNumber, col)
+                    new AddTextBoxInputScopeTag(new Span(offset, xamlElement.Length), snapshot, fileName)
                     {
                         InsertPosition = offset,
                     },

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/XamlElementProcessor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Processors/XamlElementProcessor.cs
@@ -227,10 +227,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 if (!string.IsNullOrWhiteSpace(value) && char.IsLetterOrDigit(value[0]))
                 {
-                    var line = snapshot.GetLineFromPosition(offset + tbIndex);
-                    var col = offset + tbIndex - line.Start.Position;
-
-                    var tag = new HardCodedStringTag(new Span(offset + tbIndex, length), snapshot, fileName, line.LineNumber, col, elementName, attributeName)
+                    var tag = new HardCodedStringTag(new Span(offset + tbIndex, length), snapshot, fileName, elementName, attributeName)
                     {
                         AttributeType = foundAttributeType,
                         Value = value,

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/AddEntryKeyboardTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/AddEntryKeyboardTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class AddEntryKeyboardTag : RapidXamlDisplayedTag
     {
-        public AddEntryKeyboardTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column, string originalXaml)
-            : base(span, snapshot, fileName, "RXT300", line, column, TagErrorType.Suggestion)
+        public AddEntryKeyboardTag(Span span, ITextSnapshot snapshot, string fileName, string originalXaml)
+            : base(span, snapshot, fileName, "RXT300", TagErrorType.Suggestion)
         {
             this.SuggestedAction = typeof(AddEntryKeyboardAction);
             this.Description = StringRes.Info_XamlAnalysisEntryWithoutKeyboardDescription;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/AddTextBoxInputScopeTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/AddTextBoxInputScopeTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class AddTextBoxInputScopeTag : RapidXamlDisplayedTag
     {
-        public AddTextBoxInputScopeTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT150", line, column, TagErrorType.Suggestion)
+        public AddTextBoxInputScopeTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT150", TagErrorType.Suggestion)
         {
             this.SuggestedAction = typeof(AddTextBoxInputScopeAction);
             this.Description = StringRes.Info_XamlAnalysisTextBoxWithoutInputScopeDescription;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/CheckBoxCheckedAndUncheckedEventsTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/CheckBoxCheckedAndUncheckedEventsTag.cs
@@ -10,8 +10,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
     public class CheckBoxCheckedAndUncheckedEventsTag : RapidXamlDisplayedTag
     {
         // https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/checkbox#handle-click-and-checked-events
-        public CheckBoxCheckedAndUncheckedEventsTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column, string existingName, bool hasChecked)
-            : base(span, snapshot, fileName, "RXT401", line, column, TagErrorType.Warning)
+        public CheckBoxCheckedAndUncheckedEventsTag(Span span, ITextSnapshot snapshot, string fileName, string existingName, bool hasChecked)
+            : base(span, snapshot, fileName, "RXT401", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(MissingCheckBoxEventAction);
             this.ToolTip = StringRes.Info_XamlAnalysisCheckBoxCheckedAndUncheckedEventsToolTip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/ColumnSpanOverflowTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/ColumnSpanOverflowTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class ColumnSpanOverflowTag : MissingDefinitionTag
     {
-        public ColumnSpanOverflowTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT104", line, column, TagErrorType.Warning)
+        public ColumnSpanOverflowTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT104", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(ColumnSpanOverflowAction);
             this.ToolTip = StringRes.Info_XamlAnalysisColumnSpanOverflowTooltip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/HardCodedStringTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/HardCodedStringTag.cs
@@ -11,8 +11,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class HardCodedStringTag : RapidXamlDisplayedTag
     {
-        public HardCodedStringTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column, string elementName, string attributeName)
-            : base(span, snapshot, fileName, "RXT200", line, column, TagErrorType.Warning)
+        public HardCodedStringTag(Span span, ITextSnapshot snapshot, string fileName, string elementName, string attributeName)
+            : base(span, snapshot, fileName, "RXT200", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(HardCodedStringAction);
             this.ToolTip = StringRes.Info_XamlAnalysisHardcodedStringTooltip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingColumnDefinitionTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingColumnDefinitionTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class MissingColumnDefinitionTag : MissingDefinitionTag
     {
-        public MissingColumnDefinitionTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT102", line, column, TagErrorType.Warning)
+        public MissingColumnDefinitionTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT102", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(AddMissingColumnDefinitionsAction);
             this.ToolTip = StringRes.Info_XamlAnalysisMissingColumnDefinitionTooltip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingDefinitionTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingDefinitionTag.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 using Microsoft.VisualStudio.Text;
-using RapidXamlToolkit.Resources;
 
 namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public abstract class MissingDefinitionTag : RapidXamlDisplayedTag
     {
-        protected MissingDefinitionTag(Span span, ITextSnapshot snapshot, string fileName, string errorCode, int line, int column, TagErrorType defaultErrorType)
-            : base(span, snapshot, fileName, errorCode, line, column, defaultErrorType)
+        protected MissingDefinitionTag(Span span, ITextSnapshot snapshot, string fileName, string errorCode, TagErrorType defaultErrorType)
+            : base(span, snapshot, fileName, errorCode, defaultErrorType)
         {
         }
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingRowDefinitionTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/MissingRowDefinitionTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class MissingRowDefinitionTag : MissingDefinitionTag
     {
-        public MissingRowDefinitionTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT101", line, column, TagErrorType.Warning)
+        public MissingRowDefinitionTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT101", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(AddMissingRowDefinitionsAction);
             this.ToolTip = StringRes.Info_XamlAnalysisMissingRowDefinitionTooltip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/NameTitleCaseTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/NameTitleCaseTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class NameTitleCaseTag : RapidXamlDisplayedTag
     {
-        public NameTitleCaseTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column, string value)
-            : base(span, snapshot, fileName, "RXT452", line, column, TagErrorType.Suggestion)
+        public NameTitleCaseTag(Span span, ITextSnapshot snapshot, string fileName, string value)
+            : base(span, snapshot, fileName, "RXT452",  TagErrorType.Suggestion)
         {
             this.SuggestedAction = typeof(MakeNameStartWithCapitalAction);
             this.ToolTip = StringRes.Info_XamlAnalysisNameTitleCaseToolTip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/RapidXamlDisplayedTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/RapidXamlDisplayedTag.cs
@@ -15,12 +15,15 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public abstract class RapidXamlDisplayedTag : RapidXamlAdornmentTag, IRapidXamlErrorListTag
     {
-        protected RapidXamlDisplayedTag(Span span, ITextSnapshot snapshot, string fileName, string errorCode, int line, int column, TagErrorType defaultErrorType)
+        protected RapidXamlDisplayedTag(Span span, ITextSnapshot snapshot, string fileName, string errorCode, TagErrorType defaultErrorType)
             : base(span, snapshot, fileName)
         {
+            var line = snapshot.GetLineFromPosition(span.Start);
+            var col = span.Start - line.Start.Position;
+
             this.ErrorCode = errorCode;
-            this.Line = line;
-            this.Column = column;
+            this.Line = line.LineNumber;
+            this.Column = col;
             this.DefaultErrorType = defaultErrorType;
         }
 

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/RowSpanOverflowTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/RowSpanOverflowTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class RowSpanOverflowTag : MissingDefinitionTag
     {
-        public RowSpanOverflowTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, "RXT103", fileName, line, column, TagErrorType.Warning)
+        public RowSpanOverflowTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, "RXT103", fileName, TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(RowSpanOverflowAction);
             this.ToolTip = StringRes.Info_XamlAnalysisRowSpanOverflowTooltip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/SelectedItemBindingModeTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/SelectedItemBindingModeTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class SelectedItemBindingModeTag : RapidXamlDisplayedTag
     {
-        public SelectedItemBindingModeTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT160", line, column, TagErrorType.Warning)
+        public SelectedItemBindingModeTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT160", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(SelectedItemBindingModeAction);
             this.ToolTip = StringRes.Info_XamlAnalysisSetBindingModeToTwoWayToolTip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UidTitleCaseTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UidTitleCaseTag.cs
@@ -9,8 +9,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
 {
     public class UidTitleCaseTag : RapidXamlDisplayedTag
     {
-        public UidTitleCaseTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column, string value)
-            : base(span, snapshot, fileName, "RXT451", line, column, TagErrorType.Suggestion)
+        public UidTitleCaseTag(Span span, ITextSnapshot snapshot, string fileName, string value)
+            : base(span, snapshot, fileName, "RXT451", TagErrorType.Suggestion)
         {
             this.SuggestedAction = typeof(MakeUidStartWithCapitalAction);
             this.ToolTip = StringRes.Info_XamlAnalysisUidTitleCaseToolTip;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UnexpectedErrorTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UnexpectedErrorTag.cs
@@ -8,7 +8,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
     public class UnexpectedErrorTag : RapidXamlDisplayedTag
     {
         public UnexpectedErrorTag(Span span, ITextSnapshot snapshot, string fileName)
-            : base(span, snapshot, fileName, "RXT999", 0, 0, TagErrorType.Error)
+            : base(span, snapshot, fileName, "RXT999", TagErrorType.Error)
         {
             this.ToolTip = string.Empty;
             this.IsInternalError = true;

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UseMediaPlayerElementTag.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/Tags/UseMediaPlayerElementTag.cs
@@ -10,8 +10,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Tags
     public class UseMediaPlayerElementTag : RapidXamlDisplayedTag
     {
         // https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.MediaElement#remarks
-        public UseMediaPlayerElementTag(Span span, ITextSnapshot snapshot, string fileName, int line, int column)
-            : base(span, snapshot, fileName, "RXT402", line, column, TagErrorType.Warning)
+        public UseMediaPlayerElementTag(Span span, ITextSnapshot snapshot, string fileName)
+            : base(span, snapshot, fileName, "RXT402", TagErrorType.Warning)
         {
             this.SuggestedAction = typeof(MediaElementAction);
             this.ToolTip = StringRes.Info_XamlAnalysisUseMediaPlayerElementToolTip;


### PR DESCRIPTION
This PR relates to Issue #199

**Description**  
Simplify tag generation by not requiring each processor to calculate line and column values when they can be calculated in a base class.
