### PR TITLE
Don't parse elements at the start of comments

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementExtractorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementExtractorTests.cs
@@ -680,6 +680,66 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         }
 
         [TestMethod]
+        public void ChildElementsInComments_NoSpaces_AreNotFound()
+        {
+            var xaml = @"<Grid>
+    <Child />
+    <!--<Child />
+    <Child />
+    <Child />-->
+    <Child />
+
+</Grid>";
+
+            var processor = new FakeXamlElementProcessor();
+
+            var processors = new List<(string, XamlElementProcessor)>
+            {
+                ("Child", processor),
+            };
+
+            this.TestParsingWithoutSnapshot(xaml, processors);
+
+            // Dont find the ones on lines after comment opening, between comment boundaries and on line with comment closing
+            // Do find elements before and after the comment
+            Assert.AreEqual(2, processor.ProcessCalledCount);
+        }
+
+        [TestMethod]
+        public void ElementsInComments_NoSpaces_AreNotFound()
+        {
+            var xaml = @"<!--<Child />-->";
+
+            var processor = new FakeXamlElementProcessor();
+
+            var processors = new List<(string, XamlElementProcessor)>
+            {
+                ("Child", processor),
+            };
+
+            this.TestParsingWithoutSnapshot(xaml, processors);
+
+            Assert.AreEqual(0, processor.ProcessCalledCount);
+        }
+
+        [TestMethod]
+        public void ElementImmediatelyAfterClosingCommentIsFound()
+        {
+            var xaml = @"<!-- --><Child />";
+
+            var processor = new FakeXamlElementProcessor();
+
+            var processors = new List<(string, XamlElementProcessor)>
+            {
+                ("Child", processor),
+            };
+
+            this.TestParsingWithoutSnapshot(xaml, processors);
+
+            Assert.AreEqual(1, processor.ProcessCalledCount);
+        }
+
+        [TestMethod]
         public void CanParseDocIfProcessorQueriesPrefixedAttribute()
         {
             var xaml = @"<Window><Grid><CheckBox IsChecked=""True"" /></Grid></Window>";

--- a/VSIX/RapidXamlToolkit/XamlAnalysis/XamlElementExtractor.cs
+++ b/VSIX/RapidXamlToolkit/XamlAnalysis/XamlElementExtractor.cs
@@ -55,13 +55,16 @@ namespace RapidXamlToolkit.XamlAnalysis
                 }
                 else if (char.IsLetterOrDigit(xaml[i]) || xaml[i] == ':')
                 {
-                    if (isIdentifyingElement)
+                    if (!inComment)
                     {
-                        currentElementName.Append(xaml[i]);
-                    }
-                    else if (isClosingElement)
-                    {
-                        closingElementName.Append(xaml[i]);
+                        if (isIdentifyingElement)
+                        {
+                            currentElementName.Append(xaml[i]);
+                        }
+                        else if (isClosingElement)
+                        {
+                            closingElementName.Append(xaml[i]);
+                        }
                     }
 
                     inLineOpeningWhitespace = false;
@@ -172,7 +175,7 @@ namespace RapidXamlToolkit.XamlAnalysis
                 }
                 else if (xaml[i] == '-')
                 {
-                    if (i > 3 && xaml.Substring(i - 3, 4) == "<!--")
+                    if (i >= 3 && xaml.Substring(i - 3, 4) == "<!--")
                     {
                         inComment = true;
                     }


### PR DESCRIPTION
This PR relates to Issue #238

**Description**  
Prevent elements in comments being passed to processors