### PR TITLE
Support `T` for mapping any type

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
@@ -2005,6 +2005,152 @@ namespace tests
             this.PositionAtStarShouldProduceExpected(code, expected, relPanelProfile);
         }
 
+        [TestMethod]
+        public void GetClass_ExcludePropertiesPurelyByName()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "Property1|Property2",
+                        Output = "$nooutput$",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
+        [TestMethod]
+        public void CanMatchOnAnyType()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "",
+                        Output = "<TextBlock Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
+        [TestMethod]
+        public void WildCardTypeMathingHasLowestPriority()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"False\" Text=\"Property1\" />"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"True\" Text=\"Property2\" />"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"False\" Text=\"Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "",
+                        Output = "<TextBlock IsInteger=\"False\" Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                    new Mapping
+                    {
+                        Type = "int",
+                        NameContains = "",
+                        Output = "<TextBlock IsInteger=\"True\" Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
         private void ClassNotFoundTest(string code)
         {
             var expected = ParserOutput.Empty;

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -1532,6 +1532,146 @@ End Module";
             this.PositionAtStarShouldProduceExpected(code, expected);
         }
 
+        [TestMethod]
+        public void GetClass_ExcludePropertiesPurelyByName()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        Public Property Property3 As String
+    EndClass
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "Property1|Property2",
+                        Output = "$nooutput$",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
+        [TestMethod]
+        public void CanMatchOnAnyType()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        Public Property Property3 As String
+    EndClass
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "",
+                        Output = "<TextBlock Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
+        [TestMethod]
+        public void WildCardTypeMathingHasLowestPriority()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        Public Property Property3 As String
+    EndClass
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"False\" Text=\"Property1\" />"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"True\" Text=\"Property2\" />"
+         + Environment.NewLine + "    <TextBlock IsInteger=\"False\" Text=\"Property3\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var nameExcludeProfile = new Profile
+            {
+                Name = "NameExcludeProfile",
+                ClassGrouping = "StackPanel",
+                FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />",
+                Mappings = new ObservableCollection<Mapping>
+                {
+                    new Mapping
+                    {
+                        Type = "T",
+                        NameContains = "",
+                        Output = "<TextBlock IsInteger=\"False\" Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                    new Mapping
+                    {
+                        Type = "integer",
+                        NameContains = "",
+                        Output = "<TextBlock IsInteger=\"True\" Text=\"$name$\" />",
+                        IfReadOnly = false,
+                    },
+                },
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, nameExcludeProfile);
+        }
+
         private void FindNoPropertiesInClass(string code)
         {
             var expectedOutput = "<StackPanel>"

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -137,12 +137,14 @@ namespace RapidXamlToolkit.Parsers
 
             if (mappingOfInterest != null)
             {
+                // Mapped a simple type
                 rawOutput = mappingOfInterest.Output;
             }
             else
             {
                 if (property.PropertyType.IsGenericTypeName())
                 {
+                    // Handle mapping of generic type
                     var wildcardGenericType = property.PropertyType.Substring(0, property.PropertyType.ToCSharpFormat().IndexOf("<", StringComparison.Ordinal)) + "<T>";
 
                     Logger?.RecordInfo(StringRes.Info_SearchingForMappingWithGenericWildcard.WithParams(wildcardGenericType));
@@ -155,8 +157,17 @@ namespace RapidXamlToolkit.Parsers
                     }
                 }
 
+                // See if there's a wildcard type mapping
+                var wildcardTypeMapping = this.GetMappingOfInterest("T", property.Name, property.IsReadOnly);
+
+                if (wildcardTypeMapping != null)
+                {
+                    rawOutput = wildcardTypeMapping.Output;
+                }
+
                 if (rawOutput == null && semModel != null)
                 {
+                    // Handle mapping of a complex type
                     var tempOutput = new StringBuilder();
                     var tempNumb = numericSubstitute;
                     foreach (var prop in this.GetAllPublicProperties(property.Symbol, semModel))

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,7 +8,7 @@ Mappings are the encapsulation of the logic for turning the properties in C# or 
 Each profile will contain multiple mappings.
 Each mapping is the specific rule for the generation of XAML for a specific property. A profile includes a configurable list of mappings for different combinations of type, name, and accessibility.
 
-A mapping can match multiple property types. To specify multiple types, separate them with the pipe (|) character.
+A mapping can match multiple property types. To specify multiple types, separate them with the pipe (|) character. To match any type specify `T`.
 
 A mapping can be made to only apply to properties that are read-only. This is useful if you want different output for properties that can be edited.
 


### PR DESCRIPTION
This PR relates to Issue #268

**Description**  
Generation profile mappings can support `T` as the value for 'Type' and will match on anything.
