### PR TITLE
Set C# language version explicitly (7.3)

### DIFF
--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -54,6 +54,7 @@
     <DocumentationFile>bin\Debug\RapidXamlToolkitExt.xml</DocumentationFile>
     <NoWarn>,1573,1591,1712,1762,NU1605,NU1608</NoWarn>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
to help Azure Pipelines (which defaults to 7.0) but code uses 7.1 features
