### PR TITLE
Misc C# parser fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,4 @@ __pycache__/
 *.xsd.cs
 *.secret
 VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/ParseRealDocumentsTests.g.cs
+VSIX/RapidXamlToolkit.Tests.Manual/Parsers/ParseRealDocumentsTests.g.cs

--- a/VSIX/RapidXamlToolkit.Tests.Manual/Parsers/ParseRealDocumentsTests.tt
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/Parsers/ParseRealDocumentsTests.tt
@@ -80,7 +80,11 @@ foreach (var subFolder in Directory.GetDirectories(rootFolder))
             {
                 string output;
 
-                if (filePath.Contains("\\obj\\") || filePath.Contains("\\AssemblyInfo.") || filePath.Contains("GlobalSuppressions."))
+                if (filePath.Contains("\\obj\\") ||
+                    filePath.Contains("\\AssemblyInfo.") ||
+                    filePath.Contains("GlobalSuppressions.") ||
+                    filePath.Contains("_postaction.") ||
+                    filePath.Contains("_gpostaction."))
                 {
                     continue;
                 }
@@ -96,7 +100,8 @@ foreach (var subFolder in Directory.GetDirectories(rootFolder))
                         this.TestContext.WriteLine($"No output after parsing '{filePath}'");
                         this.TestContext.AddResultFile(filePath);
 
-                        if (!logger.Info.Last().StartsWith("Unable to find class definition in file"))
+                        if (!logger.Info.Last().StartsWith("Unable to find class definition in file")
+                          & logger.Info.Last() != "No properties to provide output for.")
                         {
                             anyFailures = true;
                         }

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -58,6 +58,11 @@
     </Compile>
     <Compile Include="HybridTestVisualStudioAbstraction.cs" />
     <Compile Include="Options\WindowContentsTests.cs" />
+    <Compile Include="Parsers\ParseRealDocumentsTests.g.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ParseRealDocumentsTests.tt</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSettings.cs" />
     <Compile Include="TestsUsingWinAppDriver.cs" />

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
@@ -1107,5 +1107,239 @@ namespace tests
 
             this.SelectionBetweenStarsShouldProduceExpected(code, expected, noOutputProfile);
         }
+
+        [TestMethod]
+        public void AllProperties1_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public int Property1 { get; set; }",
+                "<TextBlock Name=\"Property1\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties2_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public MyType Property2 { get; set; }",
+                "<TextBlock Name=\"Property2\" Type=\"MyType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties3_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public MyType.MySubType Property3 { get; set; }",
+                "<TextBlock Name=\"Property3\" Type=\"MyType.MySubType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties4_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<string> Property4 { get; set; }",
+                "<TextBlock Name=\"Property4\" Type=\"x:String\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties5_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public string[] Property5 { get; set; }",
+                "<TextBlock Name=\"Property5\" Type=\"x:String[]\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties6_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public object Property6 { get; set; }",
+                "<TextBlock Name=\"Property6\" Type=\"x:Object\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties7_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public ISomething Property7 { get; set; }",
+                "<TextBlock Name=\"Property7\" Type=\"ISomething\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties8_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public MyType.MyGenericType<int> Property8 { get; set; }",
+                "<TextBlock Name=\"Property8\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties11_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public int? Property11 { get; set; }",
+                "<TextBlock Name=\"Property11\" Type=\"x:Int32?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties12_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public MyType.MySubStruct? Property12 { get; set; }",
+                "<TextBlock Name=\"Property12\" Type=\"MyType.MySubStruct?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties13_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<int> Property13 { get; set; }",
+                "<TextBlock Name=\"Property13\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties14_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<MyType.MySubStruct> Property14 { get; set; }",
+                "<TextBlock Name=\"Property14\" Type=\"MyType.MySubStruct\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties15_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public object? Property15 { get; set; }",
+                "<TextBlock Name=\"Property15\" Type=\"x:Object?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties16_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public ISomething? Property16 { get; set; }",
+                "<TextBlock Name=\"Property16\" Type=\"ISomething?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties17_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<object> Property17 { get; set; }",
+                "<TextBlock Name=\"Property17\" Type=\"x:Object\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties18_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<ISomething> Property18 { get; set; }",
+                "<TextBlock Name=\"Property18\" Type=\"ISomething\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties19_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<MyType.MyGenericType<int>> Property19 { get; set; }",
+                "<TextBlock Name=\"Property19\" Type=\"MyType.MyGenericType<x:Int32>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties21_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<Nullable<int>> Property21 { get; set; }",
+                "<TextBlock Name=\"Property21\" Type=\"Nullable<x:Int32>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties22_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<MyType> Property22 { get; set; }",
+                "<TextBlock Name=\"Property22\" Type=\"MyType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties23_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<MyType.MySubType> Property23 { get; set; }",
+                "<TextBlock Name=\"Property23\" Type=\"MyType.MySubType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties24_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<int?> Property24 { get; set; }",
+                "<TextBlock Name=\"Property24\" Type=\"x:Int32?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties25_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<string[]> Property25 { get; set; }",
+                "<TextBlock Name=\"Property25\" Type=\"x:String[]\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties26_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<object> Property26 { get; set; }",
+                "<TextBlock Name=\"Property26\" Type=\"x:Object\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties27_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<ISomething> Property27 { get; set; }",
+                "<TextBlock Name=\"Property27\" Type=\"ISomething\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties28_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<List<string>> Property28 { get; set; }",
+                "<TextBlock Name=\"Property28\" Type=\"List<x:String>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties29_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public List<MyType.MyGenericType<int>> Property29 { get; set; }",
+                "<TextBlock Name=\"Property29\" Type=\"MyType.MyGenericType<x:Int32>\" />");
+        }
+
+        // This is based on GetCSharpClassTests.GetClassWithAllTheProperties
+        private void GetNameAndType(string property, string xaml)
+        {
+            var code = @"
+namespace tests
+{
+    public class TestClass
+    {
+        ☆" + property + @"
+    }
+}";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Name=\"$name$\" Type=\"$type$\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "IgNoRe",
+                Output = xaml,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/StarsRepresentCaretInDocsTests.cs
@@ -391,7 +391,12 @@ namespace RapidXamlToolkit.Tests.Parsers
         private void AssertOutput(ParserOutput expected, ParserOutput actual)
         {
             Assert.AreEqual(expected.OutputType, actual.OutputType);
-            Assert.AreEqual(expected.Name, actual.Name);
+
+            if (expected.Name != "IgNoRe")
+            {
+                Assert.AreEqual(expected.Name, actual.Name);
+            }
+
             StringAssert.AreEqual(expected.Output, actual.Output);
         }
 

--- a/VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
+++ b/VSIX/RapidXamlToolkit/DragDrop/DropHandlerLogic.cs
@@ -38,7 +38,7 @@ namespace RapidXamlToolkit.DragDrop
                                           : (IDocumentParser)new VisualBasicParser(this.logger, projectType, indent, this.profileOverride);
 
             // IndexOf is allowing for "class " in C# and "Class " in VB
-            var cursorPos = fileContents.IndexOf("lass ");
+            var cursorPos = fileContents.FirstIndexOf(" class ", " Class ");
 
             if (cursorPos == -1 && fileExt == ".vb")
             {

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -320,7 +320,7 @@ namespace RapidXamlToolkit.Parsers
                         var prefix = string.IsNullOrWhiteSpace(namePrefix) ? property.Name : $"{namePrefix}.{property.Name}";
 
                         // Don't get into an infinite loop when a property has the same type as the containing class.
-                        if (prefix == prop.Name)
+                        if (prefix.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries).Contains(prop.Name))
                         {
                             break;
                         }
@@ -688,7 +688,8 @@ namespace RapidXamlToolkit.Parsers
 
         private Mapping GetMappingOfInterest(string type, string name, bool isReadOnly)
         {
-            var typeMappings = this.Profile.Mappings.Where(m => type.ToCSharpFormat().MatchesAnyOfInCSharpFormat(m.Type)).ToList();
+            var typeMappings = this.Profile.Mappings.Where(
+                m => type.WithoutNamespaces().ToCSharpFormat().MatchesAnyOfInCSharpFormat(m.Type)).ToList();
 
             if (!isReadOnly)
             {
@@ -711,8 +712,8 @@ namespace RapidXamlToolkit.Parsers
             if (mappingOfInterest == null)
             {
                 Logger?.RecordInfo(StringRes.Info_LookingForReadWriteMappings);
-                mappingOfInterest = typeMappings.FirstOrDefault(m => name.ToLowerInvariant().ContainsAnyOf(m.NameContains.ToLowerInvariant()) && !m.IfReadOnly)
-                                 ?? typeMappings.FirstOrDefault(m => string.IsNullOrWhiteSpace(m.NameContains) && !m.IfReadOnly);
+                mappingOfInterest = typeMappings.FirstOrDefault(m => name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty) && !m.IfReadOnly)
+                                 ?? typeMappings.FirstOrDefault(m => string.IsNullOrWhiteSpace(m?.NameContains) && !m.IfReadOnly);
             }
 
             return mappingOfInterest;

--- a/VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -106,6 +106,16 @@ namespace RapidXamlToolkit
             return result;
         }
 
+        public static string WithoutNamespaces(this string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries).Last();
+        }
+
         public static bool IsGenericTypeName(this string value)
         {
             if (value == null)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -51,7 +51,7 @@ Profile settings and mappings can include placeholders. A placeholder is somethi
 - **$name$** Property name.
 - **$safename** Property name formatted for use as an `x:Name` within XAML.
 - **$namewithspaces$** Property name with spaces inserted between words if the name is camelCase or PascalCase.
-- **$type$** Property type.
+- **$type$** Property type. If a generic type this will be the inner type.
 - **$incint$** Incrementing integer. A number (starting at zero) that will increase with each property that is matched in a class.
 - **$repint$** Repeating integer. The same number that was last used, repeated without increment. Useful when you want output with multiple items in the same row.
 - **$subprops$** Sub-properties. Is replaced with output from the sub-property mapping for each property of the matched type. Useful when outputting collections of items.


### PR DESCRIPTION
This PR relates to Issue #259 

**Description**  
 
Handles potential issues when parsing C# code
- Better detect the class definition on DragDrop when the string "class" appears before the definition
- Better handling for dropped files that don't contain classes
- Improved handling for non-trivial generic property types
- Handle fully qualified type names in more scenarios
- Handle recursive (direct & indirect) property types