### PR TITLE
Enable use of attribute based placeholders in subproperty output

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
@@ -2452,6 +2452,58 @@ namespace tests
             this.PositionAtStarShouldProduceExpected(code, expected);
         }
 
+        [TestMethod]
+        public void SubPropertyOutputCanUseAttributes()
+        {
+            var code = @"
+namespace tests
+{
+    public class ProductsViewModel☆
+    {
+        public List<Product> AllProducts { get; set; }
+    }
+
+    public class Product
+    {
+        [Display(Name=""SKU"")]
+        public int ProductId { get; set; }
+        public string ProductName { get; set; }
+        public string Description { get; set; }
+        public double UnitPrice { get; set; }
+    }
+}";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_SKU\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_ProductName\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_Description\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SP_UnitPrice\" />"
+         + Environment.NewLine + "    </StackPanel>"
+         + Environment.NewLine + "</Grid>";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "Grid";
+            profile.FallbackOutput = "<TextBlock Text=\"FB_$name$\" />";
+            profile.SubPropertyOutput = "<TextBlock Text=\"SP_$att:Display:[Name]::@name@$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "List<T>",
+                IfReadOnly = false,
+                NameContains = string.Empty,
+                Output = "<StackPanel>$subprops$</StackPanel>",
+            });
+
+            var expected = new ParserOutput
+            {
+                Name = "ProductsViewModel",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
         private void ClassNotFoundTest(string code)
         {
             var expected = ParserOutput.Empty;

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -186,7 +186,7 @@ namespace RapidXamlToolkit.Parsers
                 {
                     Logger?.RecordInfo(StringRes.Info_GettingSubPropertyOutput.WithParams(subprop.Name));
 
-                    var (output, counter) = this.GetSubPropertyOutputAndCounter(subprop.Name, numericSubstitute: numericSubstitute);
+                    var (output, counter) = this.GetSubPropertyOutputAndCounter(subprop, numericSubstitute: numericSubstitute);
 
                     numericSubstitute = counter;
                     result.Add(output);
@@ -197,7 +197,7 @@ namespace RapidXamlToolkit.Parsers
                 Logger?.RecordInfo(StringRes.Info_PropertyTypeHasNoSubProperties.WithParams(property.Name, property.PropertyType));
 
                 // There are no subproperties so leave blank
-                var (output, counter) = this.GetSubPropertyOutputAndCounter(string.Empty, numericSubstitute: numericSubstitute);
+                var (output, counter) = this.GetSubPropertyOutputAndCounter(PropertyDetails.Empty, numericSubstitute: numericSubstitute);
 
                 numericSubstitute = counter;
                 result.Add(output);

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -268,10 +268,10 @@ namespace RapidXamlToolkit.Parsers
             return (output, prop.Name, counter);
         }
 
-        protected (string output, int counter) GetSubPropertyOutputAndCounter(string name, int numericSubstitute)
+        protected (string output, int counter) GetSubPropertyOutputAndCounter(PropertyDetails property, int numericSubstitute)
         {
             // Type is blank as it's can't be used in a subproperty
-            return this.FormatOutput(this.Profile.SubPropertyOutput, type: string.Empty, name: name, numericSubstitute: numericSubstitute, symbol: null, attributes: null, getSubPropertyOutput: null);
+            return this.FormatOutput(this.Profile.SubPropertyOutput, type: string.Empty, name: property.Name, numericSubstitute: numericSubstitute, symbol: property.Symbol, attributes: property.Attributes, getSubPropertyOutput: null);
         }
 
         protected (string output, int counter) GetPropertyOutputAndCounter(PropertyDetails property, int numericSubstitute, SemanticModel semModel, Func<(List<string> strings, int count)> getSubPropertyOutput = null, string namePrefix = "")

--- a/VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
@@ -8,6 +8,14 @@ namespace RapidXamlToolkit.Parsers
 {
     public class PropertyDetails
     {
+        public static PropertyDetails Empty => new PropertyDetails()
+        {
+            Name = string.Empty,
+            PropertyType = string.Empty,
+            IsReadOnly = false,
+            Symbol = null,
+        };
+
         public string Name { get; set; }
 
         public string PropertyType { get; set; }

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -189,7 +189,7 @@ namespace RapidXamlToolkit.Parsers
                 {
                     Logger?.RecordInfo(StringRes.Info_GettingSubPropertyOutput.WithParams(subprop.Name));
 
-                    var (output, counter) = this.GetSubPropertyOutputAndCounter(subprop.Name, numericSubstitute: numericSubstitute);
+                    var (output, counter) = this.GetSubPropertyOutputAndCounter(subprop, numericSubstitute: numericSubstitute);
 
                     numericSubstitute = counter;
                     result.Add(output);
@@ -200,7 +200,7 @@ namespace RapidXamlToolkit.Parsers
                 Logger?.RecordInfo(StringRes.Info_PropertyTypeHasNoSubProperties.WithParams(property.Name, property.PropertyType));
 
                 // There are no subproperties so leave blank
-                var (output, counter) = this.GetSubPropertyOutputAndCounter(string.Empty, numericSubstitute: numericSubstitute);
+                var (output, counter) = this.GetSubPropertyOutputAndCounter(PropertyDetails.Empty, numericSubstitute: numericSubstitute);
 
                 numericSubstitute = counter;
                 result.Add(output);


### PR DESCRIPTION
This PR relates to Issue #271

**Description**  
Allow use of attribute based placeholders in sub-property output.

