### PR TITLE
Improve C# & VB Parsers

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
@@ -1316,6 +1316,22 @@ namespace tests
                 "<TextBlock Name=\"Property29\" Type=\"MyType.MyGenericType<x:Int32>\" />");
         }
 
+        [TestMethod]
+        public void AllProperties41_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public int?[] Property41 { get; set; }",
+                "<TextBlock Name=\"Property41\" Type=\"x:Int32?[]\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties42_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public Nullable<int>[] Property42 { get; set; }",
+                "<TextBlock Name=\"Property42\" Type=\"Nullable<x:Int32>[]\" />");
+        }
+
         // This is based on GetCSharpClassTests.GetClassWithAllTheProperties
         private void GetNameAndType(string property, string xaml)
         {

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
@@ -1332,6 +1332,22 @@ namespace tests
                 "<TextBlock Name=\"Property42\" Type=\"Nullable<x:Int32>[]\" />");
         }
 
+        [TestMethod]
+        public void AllProperties43_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public (int, string) Property43 { get; set; }",
+                "<TextBlock Name=\"Property43\" Type=\"Tuple\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties44_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "public (int id, string name) Property44 { get; set; }",
+                "<TextBlock Name=\"Property44\" Type=\"Tuple\" />");
+        }
+
         // This is based on GetCSharpClassTests.GetClassWithAllTheProperties
         private void GetNameAndType(string property, string xaml)
         {

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -1734,15 +1734,14 @@ End Namespace";
         public void GetClassWithRecursivePropertyTypes_AndSpecificMapping()
         {
             var code = @"
-namespace tests
-{
-    public class Detail☆
-    {
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public List<Detail> Dependencies { get; set; } = new List<Detail>();
-    }
-}";
+Namespace tests
+    Public Class Detail☆
+        Public Property Name As String
+        Public Property Description As String
+        Public Property Dependencies As List(Of Detail) = New List(Of Detail)()
+    End Class
+End Namespace
+";
 
             var expectedOutput = "<StackPanel>"
          + Environment.NewLine + "    <TextBox Text=\"{x:Bind Name, Mode=TwoWay}\" />"
@@ -1777,20 +1776,21 @@ namespace tests
         public void GetClassWithStaticDefaultProperty()
         {
             var code = @"
-namespace tests
-{
-    public class Boundary☆
-    {
-        public static Boundary Default => new Boundary
-        {
-            Low = 1,
-            High = 9,
-        };
+Namespace tests
+    Public Class Boundary☆
+        Public Shared ReadOnly Property [Default] As Boundary
+            Get
+                Return New Boundary With {
+                    .Low = 1,
+                    .High = 9
+                }
+            End Get
+        End Property
 
-        public int Low { get; set; }
-        public int High { get; set; }
-    }
-}";
+        Public Property Low As Integer
+        Public Property High As Integer
+    End Class
+End Namespace";
 
             var expectedOutput = "<StackPanel>"
          + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Low\" Value=\"{x:Bind Low, Mode=TwoWay}\" />"
@@ -1811,14 +1811,12 @@ namespace tests
         public void GetClassWithNullableProperty()
         {
             var code = @"
-namespace tests
-{
-    public class Boundary☆
-    {
-        public int Low { get; set; }
-        public int? High { get; set; }
-    }
-}";
+Namespace tests
+    Public Class Boundary☆
+        Public Property Low As Integer
+        Public Property High As Integer?
+    End Class
+End Namespace";
 
             var expectedOutput = "<StackPanel>"
          + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Low\" Value=\"{x:Bind Low, Mode=TwoWay}\" />"
@@ -1841,38 +1839,30 @@ namespace tests
             var code = @"
 Namespace tests
     Public Class TestClass☆
-    {
-        ' Basic syntaxes
-        public int Property1 { get; set; }
-        public MyType Property2 { get; set; }
-        public MyType.MySubType Property3 { get; set; }
-        public List<string> Property4 { get; set; }
-        public string[] Property5 { get; set; }
-        public object Property6 { get; set; }
-        public ISomething Property7 { get; set; }
-        public MyType.MyGenericType<int> Property8 { get; set; }
+        Public Property Property1 As Integer
+        Public Property Property2 As String
+        Public Property Property3 As MyType
+        Public Property Property4 As MyType.MySubType
+        Public Property Property5 As List(Of String)
+        Public Property Property6 As Object
+        Public Property Property7 As ISomething
+        Public Property Property8() As String
+        Public Property Property9 As MyType.MyGenericType(Of Integer)
 
-        ' nullables
-        public int? Property11 { get; set; }
-        public MyType.MySubStruct? Property12 { get; set; }
-        public Nullable<int> Property13 { get; set; }
-        public Nullable<MyType.MySubStruct> Property14 { get; set; }
-        public object? Property15 { get; set; }
-        public ISomething? Property16 { get; set; }
-        public Nullable<object> Property17 { get; set; }
-        public Nullable<ISomething> Property18 { get; set; }
-        public Nullable<MyType.MyGenericType<int>> Property19 { get; set; }
+        Public Property Property11 As Integer?
+        Public Property Property12 As List(Of Integer?)
+        Public Property Property13() As Integer?
+        Public Property Property14 As MyType.MyGenericType(Of Integer?)
+        Public Property Property15 As Nullable(Of Integer)
+        Public Property Property16 As List(Of Nullable(Of Integer))
+        Public Property Property17() As Nullable(Of Integer)
+        Public Property Property18 As MyType.MyGenericType(Of Nullable(Of Integer))
 
-        ' Generic variations
-        public List<Nullable<int>> Property21 { get; set; }
-        public List<MyType> Property22 { get; set; }
-        public List<MyType.MySubType> Property23 { get; set; }
-        public List<int?> Property24 { get; set; }
-        public List<string[]> Property25 { get; set; }
-        public List<object> Property26 { get; set; }
-        public List<ISomething> Property27 { get; set; }
-        public List<List<string>> Property28 { get; set; }
-        public List<MyType.MyGenericType<int>> Property29 { get; set; }
+        Public Property Property21 As List(Of MyType)
+        Public Property Property22 As List(Of MyType.MySubType)
+        Public Property Property23 As List(Of MyType.MyGenericType(Of Integer))
+        Public Property Property24 As List(Of List(Of String))
+        Public Property Property25 As List(Of ISomething)
     End Class
 End Namespace";
 
@@ -1883,31 +1873,27 @@ End Namespace";
             // Note that this isn't indented as it's not valid XAML
             var expectedOutput = "<StackPanel>"
          + Environment.NewLine + "<TextBlock Name=\"Property1\" Type=\"x:Int32\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property2\" Type=\"MyType\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property3\" Type=\"MyType.MySubType\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property4\" Type=\"x:String\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property5\" Type=\"x:String[]\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property2\" Type=\"x:String\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property3\" Type=\"MyType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property4\" Type=\"MyType.MySubType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property5\" Type=\"x:String\" />"
          + Environment.NewLine + "<TextBlock Name=\"Property6\" Type=\"x:Object\" />"
          + Environment.NewLine + "<TextBlock Name=\"Property7\" Type=\"ISomething\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property8\" Type=\"x:Int32\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property8\" Type=\"x:String()\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property9\" Type=\"x:Int32\" />"
          + Environment.NewLine + "<TextBlock Name=\"Property11\" Type=\"x:Int32?\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property12\" Type=\"MyType.MySubStruct?\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property13\" Type=\"x:Int32\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property14\" Type=\"MyType.MySubStruct\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property15\" Type=\"x:Object?\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property16\" Type=\"ISomething?\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property17\" Type=\"x:Object\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property18\" Type=\"ISomething\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property19\" Type=\"MyType.MyGenericType<x:Int32>\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property21\" Type=\"Nullable<x:Int32>\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property22\" Type=\"MyType\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property23\" Type=\"MyType.MySubType\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property24\" Type=\"x:Int32?\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property25\" Type=\"x:String[]\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property26\" Type=\"x:Object\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property27\" Type=\"ISomething\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property28\" Type=\"List<x:String>\" />"
-         + Environment.NewLine + "<TextBlock Name=\"Property29\" Type=\"MyType.MyGenericType<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property12\" Type=\"x:Int32?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property13\" Type=\"x:Int32?()\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property14\" Type=\"x:Int32?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property15\" Type=\"x:Int32\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property16\" Type=\"Nullable<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property17\" Type=\"Nullable(Of x:Int32)()\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property18\" Type=\"Nullable<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property21\" Type=\"MyType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property22\" Type=\"MyType.MySubType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property23\" Type=\"MyType.MyGenericType<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property24\" Type=\"List<x:String>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property25\" Type=\"ISomething\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new ParserOutput
@@ -1924,17 +1910,16 @@ End Namespace";
         public void GetClassWithIndirectNestedRecursivePropertyTypes()
         {
             var code = @"
-namespace tests
-{
-    public class Adult☆
-    {
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public Adult Partner { get; set; }
-        public Adult Parent1 { get; set; }
-        public Adult Parent2 { get; set; }
-    }
-}";
+Namespace tests
+    Public Class Adult☆
+        Public Property Name As String
+        Public Property Description As String
+        Public Property Partner As Adult
+        Public Property Parent1 As Adult
+        Public Property Parent2 As Adult
+    End Class
+End Namespace
+";
 
             var expectedOutput = "<StackPanel>"
          + Environment.NewLine + "    <TextBox Text=\"{x:Bind Name, Mode=TwoWay}\" />"

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -1730,6 +1730,241 @@ End Namespace";
             this.PositionAtStarShouldProduceExpected(code, expected);
         }
 
+        [TestMethod]
+        public void GetClassWithRecursivePropertyTypes_AndSpecificMapping()
+        {
+            var code = @"
+namespace tests
+{
+    public class Detail☆
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public List<Detail> Dependencies { get; set; } = new List<Detail>();
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <StackPanel>"
+         + Environment.NewLine + "        <TextBlock Text=\"SUBPROP_Name\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SUBPROP_Description\" />"
+         + Environment.NewLine + "        <TextBlock Text=\"SUBPROP_Dependencies\" />"
+         + Environment.NewLine + "    </StackPanel>"
+         + Environment.NewLine + "</StackPanel>";
+
+            var profile = this.FallBackProfile;
+            profile.Mappings.Add(
+                new Mapping
+                {
+                    Type = "List<Detail>",
+                    IfReadOnly = false,
+                    Output = "<StackPanel>$subprops$</StackPanel>",
+                });
+
+            var expected = new ParserOutput
+            {
+                Name = "Detail",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetClassWithStaticDefaultProperty()
+        {
+            var code = @"
+namespace tests
+{
+    public class Boundary☆
+    {
+        public static Boundary Default => new Boundary
+        {
+            Low = 1,
+            High = 9,
+        };
+
+        public int Low { get; set; }
+        public int High { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Low\" Value=\"{x:Bind Low, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"High\" Value=\"{x:Bind High, Mode=TwoWay}\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Boundary",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected);
+        }
+
+        [TestMethod]
+        public void GetClassWithNullableProperty()
+        {
+            var code = @"
+namespace tests
+{
+    public class Boundary☆
+    {
+        public int Low { get; set; }
+        public int? High { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"Low\" Value=\"{x:Bind Low, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_High\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Boundary",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected);
+        }
+
+        [TestMethod]
+        public void GetClassWithAllTheProperties()
+        {
+            var code = @"
+Namespace tests
+    Public Class TestClass☆
+    {
+        ' Basic syntaxes
+        public int Property1 { get; set; }
+        public MyType Property2 { get; set; }
+        public MyType.MySubType Property3 { get; set; }
+        public List<string> Property4 { get; set; }
+        public string[] Property5 { get; set; }
+        public object Property6 { get; set; }
+        public ISomething Property7 { get; set; }
+        public MyType.MyGenericType<int> Property8 { get; set; }
+
+        ' nullables
+        public int? Property11 { get; set; }
+        public MyType.MySubStruct? Property12 { get; set; }
+        public Nullable<int> Property13 { get; set; }
+        public Nullable<MyType.MySubStruct> Property14 { get; set; }
+        public object? Property15 { get; set; }
+        public ISomething? Property16 { get; set; }
+        public Nullable<object> Property17 { get; set; }
+        public Nullable<ISomething> Property18 { get; set; }
+        public Nullable<MyType.MyGenericType<int>> Property19 { get; set; }
+
+        ' Generic variations
+        public List<Nullable<int>> Property21 { get; set; }
+        public List<MyType> Property22 { get; set; }
+        public List<MyType.MySubType> Property23 { get; set; }
+        public List<int?> Property24 { get; set; }
+        public List<string[]> Property25 { get; set; }
+        public List<object> Property26 { get; set; }
+        public List<ISomething> Property27 { get; set; }
+        public List<List<string>> Property28 { get; set; }
+        public List<MyType.MyGenericType<int>> Property29 { get; set; }
+    End Class
+End Namespace";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Name=\"$name$\" Type=\"$type$\" />";
+
+            // Note that this isn't indented as it's not valid XAML
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "<TextBlock Name=\"Property1\" Type=\"x:Int32\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property2\" Type=\"MyType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property3\" Type=\"MyType.MySubType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property4\" Type=\"x:String\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property5\" Type=\"x:String[]\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property6\" Type=\"x:Object\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property7\" Type=\"ISomething\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property8\" Type=\"x:Int32\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property11\" Type=\"x:Int32?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property12\" Type=\"MyType.MySubStruct?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property13\" Type=\"x:Int32\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property14\" Type=\"MyType.MySubStruct\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property15\" Type=\"x:Object?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property16\" Type=\"ISomething?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property17\" Type=\"x:Object\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property18\" Type=\"ISomething\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property19\" Type=\"MyType.MyGenericType<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property21\" Type=\"Nullable<x:Int32>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property22\" Type=\"MyType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property23\" Type=\"MyType.MySubType\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property24\" Type=\"x:Int32?\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property25\" Type=\"x:String[]\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property26\" Type=\"x:Object\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property27\" Type=\"ISomething\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property28\" Type=\"List<x:String>\" />"
+         + Environment.NewLine + "<TextBlock Name=\"Property29\" Type=\"MyType.MyGenericType<x:Int32>\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "TestClass",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetClassWithIndirectNestedRecursivePropertyTypes()
+        {
+            var code = @"
+namespace tests
+{
+    public class Adult☆
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Adult Partner { get; set; }
+        public Adult Parent1 { get; set; }
+        public Adult Parent2 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Partner.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Partner.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent1.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent1.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent1.Partner.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent1.Partner.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Partner.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Partner.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Parent1.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Parent1.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Parent1.Partner.Name, Mode=TwoWay}\" />"
+         + Environment.NewLine + "    <TextBox Text=\"{x:Bind Parent2.Parent1.Partner.Description, Mode=TwoWay}\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Adult",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected);
+        }
+
         private void FindNoPropertiesInClass(string code)
         {
             var expectedOutput = "<StackPanel>"

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
@@ -1185,6 +1185,22 @@ End Namespace";
                 "<TextBlock Name=\"Property25\" Type=\"ISomething\" />");
         }
 
+        [TestMethod]
+        public void AllProperties41_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property41 As(Integer, String)",
+                "<TextBlock Name=\"Property41\" Type=\"Tuple\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties42_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property42 As(id As Integer, name As String)",
+                "<TextBlock Name=\"Property42\" Type=\"Tuple\" />");
+        }
+
         // This is based on GetVisualBasicClassTests.GetClassWithAllTheProperties
         private void GetNameAndType(string property, string xaml)
         {

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
@@ -1008,5 +1008,205 @@ End Namespace";
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
+
+        [TestMethod]
+        public void AllProperties1_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property1 As Integer",
+                "<TextBlock Name=\"Property1\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties2_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property2 As String",
+                "<TextBlock Name=\"Property2\" Type=\"x:String\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties3_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property3 As MyType",
+                "<TextBlock Name=\"Property3\" Type=\"MyType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties4_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property4 As MyType.MySubType",
+                "<TextBlock Name=\"Property4\" Type=\"MyType.MySubType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties5_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property5 As List(Of String)",
+                "<TextBlock Name=\"Property5\" Type=\"x:String\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties6_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property6 As Object",
+                "<TextBlock Name=\"Property6\" Type=\"x:Object\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties7_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property7 As ISomething",
+                "<TextBlock Name=\"Property7\" Type=\"ISomething\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties8_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property8() As String",
+                "<TextBlock Name=\"Property8\" Type=\"x:String()\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties9_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property9 As MyType.MyGenericType(Of Integer)",
+                "<TextBlock Name=\"Property9\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties11_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property11 As Integer?",
+                "<TextBlock Name=\"Property11\" Type=\"x:Int32?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties12_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property12 As List(Of Integer?)",
+                "<TextBlock Name=\"Property12\" Type=\"x:Int32?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties13_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property13() As Integer?",
+                "<TextBlock Name=\"Property13\" Type=\"x:Int32?()\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties14_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property14 As MyType.MyGenericType(Of Integer?)",
+                "<TextBlock Name=\"Property14\" Type=\"x:Int32?\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties15_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property15 As Nullable(Of Integer)",
+                "<TextBlock Name=\"Property15\" Type=\"x:Int32\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties16_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property16 As List(Of Nullable(Of Integer))",
+                "<TextBlock Name=\"Property16\" Type=\"Nullable<x:Int32>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties17_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property17() As Nullable(Of Integer)",
+                "<TextBlock Name=\"Property17\" Type=\"Nullable(Of x:Int32)()\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties18_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property18 As MyType.MyGenericType(Of Nullable(Of Integer))",
+                "<TextBlock Name=\"Property18\" Type=\"Nullable<x:Int32>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties21_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property21 As List(Of MyType)",
+                "<TextBlock Name=\"Property21\" Type=\"MyType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties22_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property22 As List(Of MyType.MySubType)",
+                "<TextBlock Name=\"Property22\" Type=\"MyType.MySubType\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties23_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property23 As List(Of MyType.MyGenericType(Of Integer))",
+                "<TextBlock Name=\"Property23\" Type=\"MyType.MyGenericType<x:Int32>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties24_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property24 As List(Of List(Of String))",
+                "<TextBlock Name=\"Property24\" Type=\"List<x:String>\" />");
+        }
+
+        [TestMethod]
+        public void AllProperties25_GetNameAndType()
+        {
+            this.GetNameAndType(
+                "Public Property Property25 As List(Of ISomething)",
+                "<TextBlock Name=\"Property25\" Type=\"ISomething\" />");
+        }
+
+        // This is based on GetVisualBasicClassTests.GetClassWithAllTheProperties
+        private void GetNameAndType(string property, string xaml)
+        {
+            var code = @"
+Namespace tests
+    Public Class TestClass
+        ☆" + property + @"
+    EndClass
+End Namespace";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Name=\"$name$\" Type=\"$type$\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "IgNoRe",
+                Output = xaml,
+                OutputType = ParserOutputType.Property,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -258,6 +258,9 @@ namespace RapidXamlToolkit.Parsers
                     case ArrayTypeSyntax ats:
                         propertyType = ats.ToString();
                         break;
+                    case TupleTypeSyntax tts:
+                        propertyType = "Tuple";
+                        break;
                 }
 
                 propertyName = this.GetIdentifier(propertyDeclaration);

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -169,7 +169,6 @@ namespace RapidXamlToolkit.Parsers
             {
                 if (nts.Arity > 0)
                 {
-                    System.Diagnostics.Debug.WriteLine(symbol);
                     symbol = nts.TypeArguments.First();
                 }
             }
@@ -439,21 +438,6 @@ namespace RapidXamlToolkit.Parsers
                 if (prop.Type is GenericNameSyntax gns)
                 {
                     var t = gns.TypeArgumentList.Arguments.First();
-
-                    if (t is QualifiedNameSyntax tqns)
-                    {
-                        var right = tqns.Right;
-
-                        if (right is IdentifierNameSyntax rins)
-                        {
-                            System.Diagnostics.Debug.WriteLine(rins);
-                            t = right;
-                        }
-                        else if (right is GenericNameSyntax rgns)
-                        {
-                            t = rgns.TypeArgumentList.Arguments.First();
-                        }
-                    }
 
                     typeSymbol = this.GetTypeSymbolWithFallback(gns, semModel, prop.SyntaxTree);
                 }

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -227,7 +227,11 @@ namespace RapidXamlToolkit.Parsers
                 }
             }
 
-            if (descendantNodes.Any(n => n is SimpleAsClauseSyntax))
+            if (descendantNodes.Any(n => n is TupleTypeSyntax))
+            {
+                propertyType = "Tuple";
+            }
+            else if (descendantNodes.Any(n => n is SimpleAsClauseSyntax))
             {
                 propertyType = descendantNodes.OfType<SimpleAsClauseSyntax>().FirstOrDefault()?.Type.ToString();
             }

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -274,7 +274,6 @@ namespace RapidXamlToolkit.Parsers
                 }
             }
 
-            // Remove any namespace qualifications as we match class names as strings
             if (propertyType?.Contains(".") == true)
             {
                 if (propertyType.Contains("Of "))
@@ -286,16 +285,6 @@ namespace RapidXamlToolkit.Parsers
                     {
                         propertyType = propertyType.Substring(dotBeforeOfPos + 1);
                     }
-
-                    if (propertyType.Contains("."))
-                    {
-                        propertyType = propertyType.Substring(0, propertyType.IndexOf("Of ") + 3) +
-                                       propertyType.Substring(propertyType.LastIndexOf(".") + 1);
-                    }
-                }
-                else
-                {
-                    propertyType = propertyType.Substring(propertyType.LastIndexOf(".") + 1);
                 }
             }
 


### PR DESCRIPTION
Have VB parsing rules behave like C#  - adopt changes to reflect recent C# rules changes

Ensure tuples don't cause any parsing problems - Tuples aren't supported just want to make sure they don't have inadvertent side effects
