### PR TITLE
Support generation output based on attributes

### DIFF
--- a/VSIX/RapidXamlToolkit.Tests/Extensions/StringExtensionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Extensions/StringExtensionTests.cs
@@ -585,6 +585,114 @@ namespace RapidXamlToolkit.Tests.Extensions
             this.StarIsNotInComment(xaml);
         }
 
+        [TestMethod]
+        public void RemoveAttributesFromTypes_NoAttribute()
+        {
+            Assert.AreEqual("string", "string".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_WithAttribute()
+        {
+            Assert.AreEqual("string", "[Hidden]string".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_NoAttributeButArray()
+        {
+            Assert.AreEqual("string[]", "string[]".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_WithAttributeAndArray()
+        {
+            Assert.AreEqual("string[]", "[Hidden]string[]".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_Multiple_NoAttribute()
+        {
+            Assert.AreEqual("string|int", "string|int".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_Multiple_WithAttribute()
+        {
+            Assert.AreEqual("string|int", "[Hidden]string|[Hidden]int".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_Multiple_NoAttributeButArray()
+        {
+            Assert.AreEqual("string[]|int[]", "string[]|int[]".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_Multiple_WithAttributeAndArray()
+        {
+            Assert.AreEqual("string[]|int[]", "[Hidden]string[]|[Hidden]int[]".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void RemoveAttributesFromTypes_Multiple_ManyScenarios()
+        {
+            Assert.AreEqual("string[]|int[]|bool|double", "[Hidden]string[]|int[]|[Hidden]bool|double".RemoveAttributesFromTypes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_NoAttribute()
+        {
+            Assert.AreEqual(string.Empty, "string".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_WithAttribute()
+        {
+            Assert.AreEqual("MyAttribute", "[MyAttribute]string".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_NoAttributeButArray()
+        {
+            Assert.AreEqual(string.Empty, "string[]".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttribtues_WithAttributeAndArray()
+        {
+            Assert.AreEqual("MyAttribute", "[MyAttribute]string[]".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_Multiple_NoAttribute()
+        {
+            Assert.AreEqual(string.Empty, "string|integer".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_Multiple_WithAttribute()
+        {
+            Assert.AreEqual("MyAttribute|Bar", "[MyAttribute]string|[Bar]string".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttributes_Multiple_NoAttributeButArray()
+        {
+            Assert.AreEqual(string.Empty, "string[]|bool[]".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttribtues_Multiple_WithAttributeAndArray()
+        {
+            Assert.AreEqual("MyAttribute|Foo", "[MyAttribute]string[]|[Foo]double[]".GetAttributes());
+        }
+
+        [TestMethod]
+        public void GetAttribtues_Multiple_ManyScenariosCombined()
+        {
+            Assert.AreEqual("MyAttribute|Bar|Foo", "[MyAttribute]int|[Bar]string[]|[Foo]double[]|bool[]|float".GetAttributes());
+        }
+
         private void StarIsNotInComment(string xaml)
         {
             var offset = xaml.IndexOf("☆");

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
@@ -275,7 +275,106 @@ namespace tests
          + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void AttributeForAnyTypeTakesPriorityOverSpecificType()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        [Hidden]
+        public string Property5 { get; set; }
+        [Hidden]
+        public int Property6 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void DoNotMapTypeWithAttributesIfDeclarationDoesNotHaveAttribute()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]int",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        [Hidden]
+        public string Property5 { get; set; }
+        [Hidden]
+        public int Property6 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new ParserOutput

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
@@ -402,5 +402,102 @@ namespace tests
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
+
+        [TestMethod]
+        public void CanMapMultipleTypesWithAttributesInSingleMapping()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]int|[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_$type$_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        [Hidden]
+        public string Property5 { get; set; }
+        [Hidden]
+        public int Property6 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_x:String_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_x:Int32_Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void CanMapMultipleAttributesToSameTypeInSingleMapping()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Foo]int|[Bar]int",
+                NameContains = "",
+                Output = "<TextBlock Text=\"FOOBAR_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        [Foo]
+        public int Property5 { get; set; }
+        [Bar]
+        public int Property6 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FOOBAR_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FOOBAR_Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
@@ -1,0 +1,291 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+    [TestClass]
+    public class GetCSharpAttributeTypeTests : CSharpTestsBase
+    {
+        [TestMethod]
+        public void GetClassAllAttributedTypeCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "object",
+                NameContains = "",
+                Output = "<TextBlock Text=\"OBJECT_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        public object Property3 { get; set; }
+        public double Property4 { get; set; }
+        [Hidden]
+        public string Property5 { get; set; }
+        [Hidden]
+        public int Property6 { get; set; }
+        [Hidden]
+        public object Property7 { get; set; }
+        [Hidden]
+        public double Property8 { get; set; }
+        [Awesome]
+        public string Property9 { get; set; }
+        [Awesome]
+        public int Property10 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"OBJECT_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property6\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property7\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property8\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property9\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetAttributedTypeAndNameContainsCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "2",
+                Output = "<TextBlock Text=\"STRING2_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "4",
+                Output = "<TextBlock Text=\"HIDDEN_STRING4_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        [Hidden]
+        public string Property1 { get; set; }
+        [Hidden]
+        public string Property2 { get; set; }
+        [Hidden]
+        public string Property3 { get; set; }
+        [Hidden]
+        public string Property4 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING2_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING4_Property4\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetAttributedTypeAndReadOnlyCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_RO_$name$\" />",
+                IfReadOnly = true,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_RO_$name$\" />",
+                IfReadOnly = true,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        [Hidden]
+        public string Property1 { get; set; }
+        [Hidden]
+        public string Property2 { get; set; }
+        [Hidden]
+        public string Property3 { get; set; }
+        [Hidden]
+        public string Property4 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_RO_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property4\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetClassAttributeWithoutType()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public string Property1 { get; set; }
+        public int Property2 { get; set; }
+        [Hidden]
+        public string Property5 { get; set; }
+        [Hidden]
+        public int Property6 { get; set; }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+    }
+}

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributeTypeTests.cs
@@ -15,6 +15,8 @@ namespace RapidXamlToolkit.Tests.Parsers
         public void GetClassAllAttributedTypeCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -102,6 +104,8 @@ namespace tests
         public void GetAttributedTypeAndNameContainsCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -147,9 +151,11 @@ namespace tests
     }
 }";
 
+            // Note that property1 test does not start "STRING_" because the mapping with an attribute takes priority over the one without.
+            // Note that property2 test does not start "STRING2_" because the attribute/Type mapping takes priority over name.
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING2_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING4_Property4\" />"
          + Environment.NewLine + "</StackPanel>";
@@ -168,6 +174,8 @@ namespace tests
         public void GetAttributedTypeAndReadOnlyCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -205,17 +213,19 @@ namespace tests
         [Hidden]
         public string Property1 { get; set; }
         [Hidden]
-        public string Property2 { get; set; }
+        public string Property2 { get; private set; }
         [Hidden]
         public string Property3 { get; set; }
         [Hidden]
-        public string Property4 { get; set; }
+        public string Property4 { get; private set; }
     }
 }";
 
+            // Note that property1 test does not start "STRING_" because the mapping with an attribute takes priority over the one without.
+            // Note that property2 test does not start "STRING2_" because the attribute/Type mapping takes priority over name.
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_RO_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property4\" />"
          + Environment.NewLine + "</StackPanel>";
@@ -234,6 +244,8 @@ namespace tests
         public void GetClassAttributeWithoutType()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "T",
@@ -271,7 +283,7 @@ namespace tests
 }";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property1\" />"
          + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
@@ -291,11 +303,13 @@ namespace tests
         public void AttributeForAnyTypeTakesPriorityOverSpecificType()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
                 NameContains = "",
-                Output = "<TextBlock Text=\"T_$name$\" />",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
                 IfReadOnly = false,
             });
             profile.Mappings.Add(new Mapping
@@ -341,11 +355,13 @@ namespace tests
         public void DoNotMapTypeWithAttributesIfDeclarationDoesNotHaveAttribute()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
                 NameContains = "",
-                Output = "<TextBlock Text=\"T_$name$\" />",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
                 IfReadOnly = false,
             });
             profile.Mappings.Add(new Mapping

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXamlToolkit.Options;
 using RapidXamlToolkit.Parsers;

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
@@ -268,7 +268,104 @@ End Namespace
          + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void AttributeForAnyTypeTakesPriorityOverSpecificType()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        <Hidden>
+        Public Property Property5 As String
+        <Hidden>
+        Public Property Property6 As Integer
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void DoNotMapTypeWithAttributesIfDeclarationDoesNotHaveAttribute()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]int",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        <Hidden>
+        Public Property Property5 As String
+        <Hidden>
+        Public Property Property6 As Integer
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
          + Environment.NewLine + "</StackPanel>";
 
             var expected = new ParserOutput

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
@@ -1,0 +1,284 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+    [TestClass]
+    public class GetVisualBasicAttributeTypeTests : CSharpTestsBase
+    {
+        [TestMethod]
+        public void GetClassAllAttributedTypeCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "object",
+                NameContains = "",
+                Output = "<TextBlock Text=\"OBJECT_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        Public Property Property3 As Object
+        Public Property Property4 As Double
+        <Hidden>
+        Public Property Property5 As String
+        <Hidden>
+        Public Property Property6 As Integer
+        <Hidden>
+        Public Property Property7 As Object
+        <Hidden>
+        Public Property Property8 As Double
+        <Awesome>
+        Public Property Property9 As String
+        <Awesome>
+        Public Property Property10 As Integer
+    End Class
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"OBJECT_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property6\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property7\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_T_Property8\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property9\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetAttributedTypeAndNameContainsCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "2",
+                Output = "<TextBlock Text=\"STRING2_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "4",
+                Output = "<TextBlock Text=\"HIDDEN_STRING4_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        <Hidden>
+        Public Property Property1 As String
+        <Hidden>
+        Public Property Property2 As String
+        <Hidden>
+        Public Property Property3 As String
+        <Hidden>
+        Public Property Property4 As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING2_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING4_Property4\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetAttributedTypeAndReadOnlyCombinations()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_RO_$name$\" />",
+                IfReadOnly = true,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_RO_$name$\" />",
+                IfReadOnly = true,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        <Hidden>
+        Public Property Property1 As String
+        <Hidden>
+        Public Property Property2 As String
+        <Hidden>
+        Public Property Property3 As String
+        <Hidden>
+        Public Property Property4 As String
+    End Class
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_RO_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property4\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void GetClassAttributeWithoutType()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "T",
+                NameContains = "",
+                Output = "<TextBlock Text=\"T_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        <Hidden>
+        Public Property Property5 As String
+        <Hidden>
+        Public Property Property6 As Integer
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property10\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+    }
+}

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
@@ -391,5 +391,100 @@ End Namespace
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
+
+        [TestMethod]
+        public void CanMapMultipleTypesWithAttributesInSingleMapping()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Hidden]integer|[Hidden]string",
+                NameContains = "",
+                Output = "<TextBlock Text=\"HIDDEN_$type$_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        <Hidden>
+        Public Property Property5 As String
+        <Hidden>
+        Public Property Property6 As Integer
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_x:String_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_x:Int32_Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void CanMapMultipleAttributesToSameTypeInSingleMapping()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Foo]integer|[Bar]integer",
+                NameContains = "",
+                Output = "<TextBlock Text=\"FOOBAR_$name$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Property Property1 As String
+        Public Property Property2 As Integer
+        <Foo>
+        Public Property Property5 As Integer
+        <Bar>
+        Public Property Property6 As Integer
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FALLBACK_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FOOBAR_Property5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"FOOBAR_Property6\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributeTypeTests.cs
@@ -9,12 +9,14 @@ using RapidXamlToolkit.Parsers;
 namespace RapidXamlToolkit.Tests.Parsers
 {
     [TestClass]
-    public class GetVisualBasicAttributeTypeTests : CSharpTestsBase
+    public class GetVisualBasicAttributeTypeTests : VisualBasicTestsBase
     {
         [TestMethod]
         public void GetClassAllAttributedTypeCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -100,6 +102,8 @@ End Namespace";
         public void GetAttributedTypeAndNameContainsCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -143,9 +147,11 @@ Namespace tests
     End Class
 End Namespace";
 
+            // Note that property1 test does not start "STRING_" because the mapping with an attribute takes priority over the one without.
+            // Note that property2 test does not start "STRING2_" because the attribute/Type mapping takes priority over name.
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING2_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING4_Property4\" />"
          + Environment.NewLine + "</StackPanel>";
@@ -164,6 +170,8 @@ End Namespace";
         public void GetAttributedTypeAndReadOnlyCombinations()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
@@ -199,17 +207,17 @@ Namespace tests
         <Hidden>
         Public Property Property1 As String
         <Hidden>
-        Public Property Property2 As String
+        Public ReadOnly Property Property2 As String
         <Hidden>
         Public Property Property3 As String
         <Hidden>
-        Public Property Property4 As String
+        Public ReadOnly Property Property4 As String
     End Class
 End Namespace";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_RO_Property2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property3\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_RO_Property4\" />"
          + Environment.NewLine + "</StackPanel>";
@@ -228,6 +236,8 @@ End Namespace";
         public void GetClassAttributeWithoutType()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "T",
@@ -264,7 +274,7 @@ End Namespace
 ";
 
             var expectedOutput = "<StackPanel>"
-         + Environment.NewLine + "    <TextBlock Text=\"STRING_Property1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"T_Property1\" />"
          + Environment.NewLine + "    <TextBlock Text=\"T_Property2\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN_STRING_Property5\" />"
          + Environment.NewLine + "    <TextBlock Text=\"HIDDEN__Property6\" />"
@@ -284,11 +294,13 @@ End Namespace
         public void AttributeForAnyTypeTakesPriorityOverSpecificType()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
                 NameContains = "",
-                Output = "<TextBlock Text=\"T_$name$\" />",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
                 IfReadOnly = false,
             });
             profile.Mappings.Add(new Mapping
@@ -301,7 +313,7 @@ End Namespace
 
             var code = @"
 Namespace tests
-    Class Class1☆
+    Class Class☆1
         Public Property Property1 As String
         Public Property Property2 As Integer
         <Hidden>
@@ -333,16 +345,18 @@ End Namespace
         public void DoNotMapTypeWithAttributesIfDeclarationDoesNotHaveAttribute()
         {
             var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
             profile.Mappings.Add(new Mapping
             {
                 Type = "string",
                 NameContains = "",
-                Output = "<TextBlock Text=\"T_$name$\" />",
+                Output = "<TextBlock Text=\"STRING_$name$\" />",
                 IfReadOnly = false,
             });
             profile.Mappings.Add(new Mapping
             {
-                Type = "[Hidden]int",
+                Type = "[Hidden]integer",
                 NameContains = "",
                 Output = "<TextBlock Text=\"HIDDEN__$name$\" />",
                 IfReadOnly = false,

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Misc\MiscRealWorldTests.cs" />
     <Compile Include="Parsers\CSharpTestsBase.cs" />
     <Compile Include="Parsers\GetCSharpAttributesTests.cs" />
+    <Compile Include="Parsers\GetVisualBasicAttributeTypeTests.cs" />
+    <Compile Include="Parsers\GetCSharpAttributeTypeTests.cs" />
     <Compile Include="Parsers\GetVisualBasicArrayTests.cs" />
     <Compile Include="Parsers\GetCSharpClassTests.cs" />
     <Compile Include="Parsers\GetCSharpArrayTests.cs" />

--- a/VSIX/RapidXamlToolkit/StringExtensions.cs
+++ b/VSIX/RapidXamlToolkit/StringExtensions.cs
@@ -68,6 +68,19 @@ namespace RapidXamlToolkit
             return allOptions.Any(o => string.Equals(value, o, StringComparison.OrdinalIgnoreCase));
         }
 
+        public static bool Intersects(this string thisList, string otherList)
+        {
+            foreach (var item in thisList.Split('|'))
+            {
+                if (item.MatchesAnyOf(otherList))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static bool MatchesAnyOfInCSharpFormat(this string value, string options)
         {
             if (value == null)
@@ -83,6 +96,57 @@ namespace RapidXamlToolkit
             var allOptions = options.Split('|');
 
             return allOptions.Any(o => string.Equals(value, o.ToCSharpFormat(), StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static string RemoveAttributesFromTypes(this string value)
+        {
+            var result = new StringBuilder();
+
+            foreach (var item in value.Split('|'))
+            {
+                if (item.StartsWith("["))
+                {
+                    var attClosingIndex = item.IndexOf(']');
+
+                    var typeName = item.Substring(attClosingIndex + 1);
+
+                    if (string.IsNullOrWhiteSpace(typeName))
+                    {
+                        result.Append("T");
+                    }
+                    else
+                    {
+                        result.Append(typeName);
+                    }
+                }
+                else
+                {
+                    result.Append(item);
+                }
+
+                result.Append("|");
+            }
+
+            return result.ToString().TrimEnd('|');
+        }
+
+        public static string GetAttributes(this string value)
+        {
+            var result = new StringBuilder();
+
+            foreach (var item in value.Split('|'))
+            {
+                if (item.StartsWith("["))
+                {
+                    var attClosingIndex = item.IndexOf(']');
+
+                    result.Append(item.Substring(1, attClosingIndex - 1));
+
+                    result.Append("|");
+                }
+            }
+
+            return result.ToString().TrimEnd('|');
         }
 
         public static string ToCSharpFormat(this string value)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -22,6 +22,12 @@ Mappings are matched in the following order:
 
 If a property matches multiple mappings, there is no guarantee on which will be used.
 
+### Matching types with attributes
+
+It's possible to use attributes applied to properties to determine what to output. (Attributes can also be used in the output--see below.)
+To specify that a property should produce different output when a specific attribute is applied, include `[attribute-name]` before the property type. For example, to create a mapping for a property that is a `string` and has the `HiddenAttribute` applied, specify the type as `[Hidden]string`.
+To create a mapping for a property of any type that has a specific attribute applied, specify the type as `[attribute-name]T`.
+
 ### Special mappings
 
 In addition to the mappings for properties, there are also three special mappings that must be configured.


### PR DESCRIPTION
This PR relates to Issue #265

**Description**  
Allows support for generation mappings of the format `[attribute]type`.
