### PR TITLE
Handle illegal character in path exceptions

### DIFF
--- a/VSIX/RapidXamlToolkit/VisualStudioIntegration/VisualStudioAbstraction.cs
+++ b/VSIX/RapidXamlToolkit/VisualStudioIntegration/VisualStudioAbstraction.cs
@@ -141,6 +141,15 @@ namespace RapidXamlToolkit.VisualStudioIntegration
 
             var guids = this.GetProjectTypeGuids(project);
 
+            // This will be the case in CPS projects
+            if (string.IsNullOrWhiteSpace(guids))
+            {
+                if (this.ProjectUsesWpf(project))
+                {
+                    return ProjectType.Wpf;
+                }
+            }
+
             var result = ProjectType.Unknown;
 
             // Check with `Contains` as there may be multiple GUIDs specified (e.g. for programming language too)
@@ -188,6 +197,13 @@ namespace RapidXamlToolkit.VisualStudioIntegration
             }
 
             return result;
+        }
+
+        public bool ProjectUsesWpf(EnvDTE.Project project)
+        {
+            var rawContent = System.IO.File.ReadAllText(project.FullName);
+
+            return rawContent.Contains("<UseWPF>true</UseWPF>");
         }
 
         public string GetProjectTypeGuids(EnvDTE.Project proj)

--- a/VSIX/RapidXamlToolkit/VisualStudioIntegration/VisualStudioAbstraction.cs
+++ b/VSIX/RapidXamlToolkit/VisualStudioIntegration/VisualStudioAbstraction.cs
@@ -93,8 +93,9 @@ namespace RapidXamlToolkit.VisualStudioIntegration
                 foreach (var otherProj in proj.DTE.Solution.GetAllProjects())
                 {
                     // Don't check self or any shard projects to avoid infinite loops and unnecessary work.
+                    // Unique name is ususally a relative path but may not be (esp. in .NETCore projects)
                     if (otherProj.UniqueName != project.UniqueName
-                     && !System.IO.Path.GetExtension(otherProj.UniqueName).Equals(".shproj", StringComparison.OrdinalIgnoreCase))
+                     && otherProj.UniqueName.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase))
                     {
                         var item = otherProj.ProjectItems?.GetEnumerator();
 


### PR DESCRIPTION
This PR relates to Issue #287

**Description**  
Handle internal project references that are not project file paths.

Also improves detecting project type for WPF projects that use .NET Core.