### PR TITLE
Add ability to generate XAML based on methods

### DIFF
--- a/VSIX/LocalizationHelper/LocalizationHelper.csproj
+++ b/VSIX/LocalizationHelper/LocalizationHelper.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>SA0001</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
@@ -242,7 +242,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Null()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(null);
+            var result = CodeParserBase.GetSelectionMemberName(null);
 
             Assert.IsTrue(string.IsNullOrEmpty(result));
         }
@@ -250,7 +250,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Empty()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string>());
+            var result = CodeParserBase.GetSelectionMemberName(new List<string>());
 
             Assert.IsTrue(string.IsNullOrEmpty(result));
         }
@@ -258,7 +258,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_One()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string> { "one" });
+            var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one" });
 
             Assert.IsTrue(result.Equals("one"));
         }
@@ -266,7 +266,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Two()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string> { "one", "two" });
+            var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two" });
 
             Assert.IsTrue(result.Equals("one and two"));
         }
@@ -274,7 +274,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Three()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string> { "one", "two", "three" });
+            var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three" });
 
             Assert.IsTrue(result.Equals("one, two and 1 other property"));
         }
@@ -282,7 +282,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Four()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string> { "one", "two", "three", "four" });
+            var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three", "four" });
 
             Assert.IsTrue(result.Equals("one, two and 2 other properties"));
         }
@@ -290,7 +290,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         [TestMethod]
         public void GetSelectionPropertiesName_Five()
         {
-            var result = CodeParserBase.GetSelectionPropertiesName(new List<string> { "one", "two", "three", "four", "five" });
+            var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three", "four", "five" });
 
             Assert.IsTrue(result.Equals("one, two and 3 other properties"));
         }

--- a/VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Formatting/OutputGenerationTests.cs
@@ -276,7 +276,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         {
             var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three" });
 
-            Assert.IsTrue(result.Equals("one, two and 1 other property"));
+            Assert.IsTrue(result.Equals("one, two and 1 other member"));
         }
 
         [TestMethod]
@@ -284,7 +284,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         {
             var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three", "four" });
 
-            Assert.IsTrue(result.Equals("one, two and 2 other properties"));
+            Assert.IsTrue(result.Equals("one, two and 2 other members"));
         }
 
         [TestMethod]
@@ -292,7 +292,7 @@ namespace RapidXamlToolkit.Tests.Formatting
         {
             var result = CodeParserBase.GetSelectionMemberName(new List<string> { "one", "two", "three", "four", "five" });
 
-            Assert.IsTrue(result.Equals("one, two and 3 other properties"));
+            Assert.IsTrue(result.Equals("one, two and 3 other members"));
         }
 
         [TestMethod]

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
@@ -140,7 +140,7 @@ namespace tests
 
             var expected = new ParserOutput
             {
-                Name = "MyBool, MyBoolBrackets and 1 other property",
+                Name = "MyBool, MyBoolBrackets and 1 other member",
                 Output = expectedXaml,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpArrayTests.cs
@@ -88,7 +88,7 @@ namespace tests
             {
                 Name = "MyBoolBrackets",
                 Output = "<BoolBrackets />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.ArrayTestsProfile);
@@ -112,7 +112,7 @@ namespace tests
             {
                 Name = "MyArrayBool",
                 Output = "<ArrayBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.ArrayTestsProfile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpAttributesTests.cs
@@ -90,7 +90,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
@@ -115,7 +115,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
@@ -140,7 +140,7 @@ namespace tests
             {
                 Name = "UserName",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             var profile = this.displayNameProfile;
@@ -168,7 +168,7 @@ namespace tests
             {
                 Name = "UserName",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             var profile = this.displayNameProfile;
@@ -196,7 +196,7 @@ namespace tests
             {
                 Name = "UserName",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             var profile = this.displayNameProfile;
@@ -224,7 +224,7 @@ namespace tests
             {
                 Name = "UserName",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             var profile = this.displayNameProfile;
@@ -253,7 +253,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -278,7 +278,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -303,7 +303,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
@@ -328,7 +328,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
@@ -353,7 +353,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthAttributeProfile);
@@ -378,7 +378,7 @@ namespace tests
             {
                 Name = "Rating",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
@@ -402,7 +402,7 @@ namespace tests
             {
                 Name = "Rating",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
@@ -427,7 +427,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -452,7 +452,7 @@ namespace tests
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
@@ -1306,7 +1306,7 @@ public class Class1
             {
                 Name = "SomeProperty",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpClassTests.cs
@@ -421,27 +421,6 @@ namespace tests
         }
 
         [TestMethod]
-        public void GetClassWithFocusInMethod()
-        {
-            var code = @"
-namespace tests
-{
-    class Class1
-    {
-        public string Property1 { get; set; }
-
-      ☆  public bool IsSpecial(string someValue)
-        {
-            return true;
-        }☆
-    }
-}
-";
-
-            this.FindSinglePropertyInClass(code);
-        }
-
-        [TestMethod]
         public void GetClassWithFocusInField()
         {
             var code = @"

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -19,6 +19,11 @@ namespace tests
 {
     class Class1☆
     {
+        public Class1()
+        {
+            // Constructor is a method but shouldn't match anything
+        }
+
         public void OnPhotoTaken(CameraControlEventArgs args) { }
 
         public void ZoomIn() => _zoomService?.ZoomIn();
@@ -30,6 +35,16 @@ namespace tests
         public async void Redo() {  }
 
         public void MethodName(string name, int amount) { }
+
+        private void DoNotMatchBecausePrivate() { }
+
+        public int DoNotMatchBecauseOfReturnType() { }
+
+        internal void DoNotMatchBecauseInternal() { }
+
+        protected void DoNotMatchBecauseProtected() { }
+
+        public void DoNotMatchAsGeneric<T>() { }
     }
 }";
 

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -408,6 +408,164 @@ namespace tests
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
 
+        [TestMethod]
+        public void MethodOutputCanBeInGrid_OneColumn()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+    }
+}";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "</Grid>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "GRID-PLUS-ROWDEFS";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void MethodOutputCanBeInGrid_TwoColumns()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+    }
+}";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" Grid.Column=\"1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" Grid.Column=\"1\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" Grid.Column=\"1\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" Grid.Column=\"1\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" Grid.Column=\"1\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" Grid.Column=\"1\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "</Grid>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "GRID-PLUS-ROWDEFS-2COLS";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"NOPARAMS_$method$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"ONEPARAM_$method$_$arg1$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
         private Profile MethodTestProfile()
         {
             var profile = TestProfile.CreateEmpty();

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -566,6 +566,72 @@ namespace tests
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
 
+        [TestMethod]
+        public void FilterMethodsByName()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+
+        public async void OtherMethodNamez(string name, int amount) { }
+    }
+}";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "$nooutput$";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "e",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "e",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "z",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
+                IfReadOnly = false,
+            });
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_OtherMethodNamez_name_amount\" />"
+          + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
         private Profile MethodTestProfile()
         {
             var profile = TestProfile.CreateEmpty();

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -83,7 +83,7 @@ namespace tests
 
             var expected = new ParserOutput
             {
-                Name = "Class1",
+                Name = "OnPhotoTaken, ZoomIn and 4 other members",
                 Output = expectedOutput,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+
+    [TestClass]
+    public class GetCSharpMethodsTests : CSharpTestsBase
+    {
+        [TestMethod]
+        public void GetAllPropertyOptions()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
+                IfReadOnly = false,
+            });
+
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected);
+        }
+    }
+}

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -8,38 +8,12 @@ using RapidXamlToolkit.Parsers;
 
 namespace RapidXamlToolkit.Tests.Parsers
 {
-
     [TestClass]
     public class GetCSharpMethodsTests : CSharpTestsBase
     {
         [TestMethod]
-        public void GetAllPropertyOptions()
+        public void GetAllMethodOptions()
         {
-            var profile = TestProfile.CreateEmpty();
-            profile.ClassGrouping = "StackPanel";
-            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
-            profile.Mappings.Add(new Mapping
-            {
-                Type = "method()",
-                NameContains = "",
-                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
-                IfReadOnly = false,
-            });
-            profile.Mappings.Add(new Mapping
-            {
-                Type = "method(T)",
-                NameContains = "",
-                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
-                IfReadOnly = false,
-            });
-            profile.Mappings.Add(new Mapping
-            {
-                Type = "method(T,T)",
-                NameContains = "",
-                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
-                IfReadOnly = false,
-            });
-
             var code = @"
 namespace tests
 {
@@ -68,7 +42,6 @@ namespace tests
          + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />"
          + Environment.NewLine + "</StackPanel>";
 
-
             var expected = new ParserOutput
             {
                 Name = "Class1",
@@ -76,7 +49,172 @@ namespace tests
                 OutputType = ParserOutputType.Class,
             };
 
-            this.PositionAtStarShouldProduceExpected(code, expected);
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetAllMethodOptions_Selection()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {☆
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+    }☆
+}";
+
+            var expectedOutput = "<TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_ZoomIn\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_Undo\" />"
+         + Environment.NewLine + "<TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "<TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Selection,
+            };
+
+            this.SelectionBetweenStarsShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_NoParams()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        public void Un☆do() {  }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"NOPARAMS_Undo\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Undo",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_NoParamsLambda()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        public void Zoo☆mIn() => _zoomService?.ZoomIn();
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"NOPARAMS_ZoomIn\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "ZoomIn",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_OneParam()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        public void OnPhotoT☆aken(CameraControlEventArgs args) { }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "OnPhotoTaken",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_TwoParams()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1
+    {
+        public void Metho☆dName(string name, int amount) { }
+    }
+}";
+
+            var expectedOutput = "<TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "MethodName",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        private Profile MethodTestProfile()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
+                IfReadOnly = false,
+            });
+
+            return profile;
         }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpMethodsTests.cs
@@ -647,6 +647,59 @@ namespace tests
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
         }
 
+        [TestMethod]
+        public void FallbackIsNotUsedForMethods()
+        {
+            var code = @"
+namespace tests
+{
+    class Class1☆
+    {
+        public Class1()
+        {
+            // Constructor is a method but shouldn't match anything
+        }
+
+        public void OnPhotoTaken(CameraControlEventArgs args) { }
+
+        public void ZoomIn() => _zoomService?.ZoomIn();
+
+        public void Undo() {  }
+
+        public async void SwitchTheme(ElementTheme theme) { }
+
+        public async void Redo() {  }
+
+        public void MethodName(string name, int amount) { }
+
+        private void DoNotMatchBecausePrivate() { }
+
+        public int DoNotMatchBecauseOfReturnType() { }
+
+        internal void DoNotMatchBecauseInternal() { }
+
+        protected void DoNotMatchBecauseProtected() { }
+
+        public void DoNotMatchAsGeneric<T>() { }
+    }
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<DoNotOutputForMethods />";
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
         private Profile MethodTestProfile()
         {
             var profile = TestProfile.CreateEmpty();

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
@@ -210,7 +210,7 @@ namespace tests
 
             var expected = new ParserOutput
             {
-                Name = "MyBool, MyBoolQ and 2 other properties",
+                Name = "MyBool, MyBoolQ and 2 other members",
                 Output = expectedXaml,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpNullableTests.cs
@@ -101,7 +101,7 @@ namespace tests
             {
                 Name = "MyBoolQ",
                 Output = "<BoolQ />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -125,7 +125,7 @@ namespace tests
             {
                 Name = "MyNullableBool",
                 Output = "<NullBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -147,7 +147,7 @@ namespace tests
             {
                 Name = "MyFqNullableBool",
                 Output = "<NullBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -180,7 +180,7 @@ namespace tests
             {
                 Name = "MyListOfNullables",
                 Output = "<LBnull />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpPropertiesTests.cs
@@ -33,7 +33,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -59,7 +59,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -85,7 +85,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -113,7 +113,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -141,7 +141,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -169,7 +169,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -192,7 +192,7 @@ namespace tests
                 Name = "SomeProperty",
                 Output =
                     "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"SomeProperty\" Value=\"{x:Bind SomeProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -223,7 +223,7 @@ namespace tests
             {
                 Name = "SomeProperty",
                 Output = "<Dynamic Name=\"SomeProperty\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -260,7 +260,7 @@ namespace tests
             {
                 Name = "SomeList",
                 Output = expectedXaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -285,7 +285,7 @@ namespace tests
                 Name = "MyListProperty",
                 Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\">" + Environment.NewLine +
                          "</ItemsControl>",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -307,7 +307,7 @@ namespace tests
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -329,7 +329,7 @@ namespace tests
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -351,7 +351,7 @@ namespace tests
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -373,7 +373,7 @@ namespace tests
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -392,7 +392,7 @@ class Class1
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -421,7 +421,7 @@ namespace tests
                 Name = "LastOrder",
                 Output = @"<Slider Minimum=""0"" Maximum=""100"" x:Name=""LastOrder.OrderId"" Value=""{x:Bind LastOrder.OrderId, Mode=TwoWay}"" />"
  + Environment.NewLine + @"<TextBox Text=""{x:Bind LastOrder.OrderDescription, Mode=TwoWay}"" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -461,7 +461,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:Array=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, arrayProfile);
@@ -501,7 +501,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:InvalidType=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, invalidTypeProfile);
@@ -547,7 +547,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:Order=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, orderProfile);
@@ -602,7 +602,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -656,7 +656,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -700,7 +700,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -754,7 +754,7 @@ namespace tests
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, enumProfile);
@@ -815,7 +815,7 @@ namespace tests
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, enumProfile);
@@ -873,7 +873,7 @@ namespace tests
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             await this.PositionAtStarShouldProduceExpectedUsingAdditionalFiles(code, expected, enumProfile, code2);
@@ -925,7 +925,7 @@ namespace tests
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, enumProfile);
@@ -974,7 +974,7 @@ namespace tests
             {
                 Name = "LastOrder",
                 Output = "<TextBlock x:IsOrder=\"True\" Text=\"LastOrder\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             await this.PositionAtStarShouldProduceExpectedUsingAdditionalFiles(code, expected, orderProfile, code2);
@@ -996,7 +996,7 @@ namespace tests
             {
                 Name = "SomeProperty",
                 Output = "<TextBlock Text=\"FALLBACK_SomeProperty\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected);
@@ -1050,7 +1050,7 @@ namespace tests
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, enumProfile);
@@ -1368,7 +1368,7 @@ namespace tests
             {
                 Name = "IgNoRe",
                 Output = xaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpSelectionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpSelectionTests.cs
@@ -44,7 +44,7 @@ namespace tests
 
             var expected = new ParserOutput
             {
-                Name = "Property1, Property2 and 6 other properties",
+                Name = "Property1, Property2 and 6 other members",
                 Output = expectedOutput,
                 OutputType = ParserOutputType.Selection,
             };
@@ -223,26 +223,6 @@ namespace tests
  ☆       private int _someField = 3;☆
 
         public string Property2 { get; private set; }
-    }
-}";
-
-            this.NoPropertiesFoundInSelectionTest(code);
-        }
-
-        [TestMethod]
-        public void GetSelectionNothingFoundOverMethod()
-        {
-            var code = @"
-namespace tests
-{
-    class SomeClass
-    {
-        public string Property2 { get; private set; }
-
-      ☆  public bool IsSpecial(string someValue)
-        {
-            return true;
-        }☆
     }
 }";
 

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpStructsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetCSharpStructsTests.cs
@@ -70,7 +70,7 @@ namespace tests
             {
                 Name = "Property2",
                 Output = "<MyStruct />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -127,7 +127,7 @@ namespace tests
             {
                 Name = "MyListProperty",
                 Output = expectedXaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
@@ -126,7 +126,7 @@ End Namespace";
 
             var expected = new ParserOutput
             {
-                Name = "MyBool, MyArray and 1 other property",
+                Name = "MyBool, MyArray and 1 other member",
                 Output = expectedXaml,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicArrayTests.cs
@@ -82,7 +82,7 @@ End Namespace";
             {
                 Name = "MyArray",
                 Output = "<Array />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.ArrayTestsProfile);
@@ -102,7 +102,7 @@ End Namespace";
             {
                 Name = "MyArrayBool",
                 Output = "<ArrayBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.ArrayTestsProfile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicAttributesTests.cs
@@ -91,7 +91,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
@@ -114,7 +114,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);
@@ -138,7 +138,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -161,7 +161,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -184,7 +184,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
@@ -208,7 +208,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
@@ -231,7 +231,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthAttributeProfile);
@@ -254,7 +254,7 @@ End Namespace";
             {
                 Name = "Rating",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
@@ -276,7 +276,7 @@ End Namespace";
             {
                 Name = "Rating",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
@@ -311,7 +311,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.maxLengthProfile);
@@ -334,7 +334,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -357,7 +357,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameAndMaxLengthProfile);
@@ -380,7 +380,7 @@ End Namespace";
             {
                 Name = "Rating",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.rangeProfile);
@@ -403,7 +403,7 @@ End Namespace";
             {
                 Name = "Name",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.displayNameProfile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -813,7 +813,7 @@ End Class";
             {
                 Name = "SomeProperty",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicClassTests.cs
@@ -400,22 +400,6 @@ End Class
         }
 
         [TestMethod]
-        public void GetClassWithFocusInMethod()
-        {
-            var code = @"
-Public Class Class1
-        Public Property Property1 As String
-
-      ☆ Public Function IsSpecial(someValue As String) As Boolean
-            Return True
-        End Function☆
-End Class
-";
-
-            this.FindSinglePropertyInClass(code);
-        }
-
-        [TestMethod]
         public void GetClassWithFocusInField()
         {
             var code = @"

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicMethodsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicMethodsTests.cs
@@ -1,0 +1,760 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXamlToolkit.Options;
+using RapidXamlToolkit.Parsers;
+
+namespace RapidXamlToolkit.Tests.Parsers
+{
+    [TestClass]
+    public class GetVisualBasicMethodsTests : VisualBasicTestsBase
+    {
+        [TestMethod]
+        public void GetAllMethodOptions()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub New()
+            ' Constructor is a method but shouldn't match anything
+        End Sub
+
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+
+        Private Sub DoNotMatchBecausePrivate()
+        End Sub
+
+        Public Function DoNotMatchBecauseOfReturnType() As Integer
+        End Function
+
+        Friend Sub DoNotMatchBecauseInternal()
+        End Sub
+
+        Protected Sub DoNotMatchBecauseProtected()
+        End Sub
+
+        Public Sub DoNotMatchAsGeneric(Of T)()
+        End Sub
+    End Class
+End Namespace";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetAllMethodOptions_Selection()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub☆
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_ZoomIn\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_Undo\" />"
+         + Environment.NewLine + "<TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "<TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "<TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "OnPhotoTaken, ZoomIn and 4 other members",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Selection,
+            };
+
+            this.SelectionBetweenStarsShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_NoParams()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        Public Sub Un☆do()
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<TextBlock Text=\"NOPARAMS_Undo\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "Undo",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_OneParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        Public Sub OnPhotoT☆aken(ByVal args As CameraControlEventArgs)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "OnPhotoTaken",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void GetSingleMethod_TwoParams()
+        {
+            var code = @"
+Namespace tests
+    Class Class1
+        Public Sub Metho☆dName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />";
+
+            var expected = new ParserOutput
+            {
+                Name = "MethodName",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Member,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, this.MethodTestProfile());
+        }
+
+        [TestMethod]
+        public void CanMapMethodsBasedOnAttributes()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+
+        <DoNotGenerate>
+        Public Sub IgnoredMethodName()
+        End Sub
+
+        <DoNotGenerate>
+        Public Sub IgnoredMethodName2(ByVal name As String)
+        End Sub
+
+        <DoNotGenerate>
+        Public Sub IgnoredMethodName3(ByVal name As String, ByVal amount As Integer)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" />"
+         + Environment.NewLine + "    <One />"
+         + Environment.NewLine + "    <Two />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = this.MethodTestProfile();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[DoNotGenerate]method()",
+                NameContains = "",
+                Output = "$nooutput$",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[DoNotGenerate]method(T)",
+                NameContains = "",
+                Output = "<One />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[DoNotGenerate]method(T,T)",
+                NameContains = "",
+                Output = "<Two />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void AttributeBasedMapping_NoParams()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        <Filter0>
+        <Filter1>
+        Public Sub IgnoredMethodName1()
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName2()
+        End Sub
+    End Class
+End Namespace
+}";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <FilterOne />"
+         + Environment.NewLine + "    <FilterOne />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = this.MethodTestProfile();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method()",
+                NameContains = "",
+                Output = "<FilterOne />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void AttributeBasedMapping_IsTypeSensitive_OneParam()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        <Filter1>
+        Public Sub IgnoredMethodName1(ByVal id As Integer)
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName2(ByVal name As String)
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName3(ByVal name As String)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <FilterOne />"
+         + Environment.NewLine + "    <FilterTwo />"
+         + Environment.NewLine + "    <FilterTwo />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = this.MethodTestProfile();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(T)",
+                NameContains = "",
+                Output = "<FilterOne />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(string)",
+                NameContains = "",
+                Output = "<FilterTwo />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void AttributeBasedMapping_IsTypeSensitive_TwoParams()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        <Filter1>
+        Public Sub IgnoredMethodName1(ByVal id As Integer, ByVal refId As Integer)
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName2(ByVal name As String, ByVal id As Integer)
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName3(ByVal id As Integer, ByVal name As String)
+        End Sub
+
+        <Filter1>
+        Public Sub IgnoredMethodName4(ByVal name As String, ByVal description As String)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <FilterOne />"
+         + Environment.NewLine + "    <FilterTwo />"
+         + Environment.NewLine + "    <FilterThree />"
+         + Environment.NewLine + "    <FilterFour />"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = this.MethodTestProfile();
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(string,string)",
+                NameContains = "",
+                Output = "<FilterFour />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(string,T)",
+                NameContains = "",
+                Output = "<FilterTwo />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(T,T)",
+                NameContains = "",
+                Output = "<FilterOne />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "[Filter1]method(T,string)",
+                NameContains = "",
+                Output = "<FilterThree />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void MethodOutputCanBeInGrid_OneColumn()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+    End Class
+End Namespace";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "</Grid>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "GRID-PLUS-ROWDEFS";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" Grid.Row=\"$incint$\" />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void MethodOutputCanBeInGrid_TwoColumns()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+    End Class
+End Namespace";
+
+            var expectedOutput = "<Grid>"
+         + Environment.NewLine + "    <Grid.ColumnDefinitions>"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"Auto\" />"
+         + Environment.NewLine + "        <ColumnDefinition Width=\"*\" />"
+         + Environment.NewLine + "    </Grid.ColumnDefinitions>"
+         + Environment.NewLine + "    <Grid.RowDefinitions>"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"Auto\" />"
+         + Environment.NewLine + "        <RowDefinition Height=\"*\" />"
+         + Environment.NewLine + "    </Grid.RowDefinitions>"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" Grid.Column=\"1\" Grid.Row=\"0\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_ZoomIn\" Grid.Column=\"1\" Grid.Row=\"1\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Undo\" Grid.Column=\"1\" Grid.Row=\"2\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" Grid.Column=\"1\" Grid.Row=\"3\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" Grid.Column=\"1\" Grid.Row=\"4\" />"
+         + Environment.NewLine + "    <Lbl Grid.Column=\"0\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_MethodName_name_amount\" Grid.Column=\"1\" Grid.Row=\"5\" />"
+         + Environment.NewLine + "</Grid>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "GRID-PLUS-ROWDEFS-2COLS";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"NOPARAMS_$method$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"ONEPARAM_$method$_$arg1$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<Lbl Grid.Column=\"0\" Grid.Row=\"$incint$\" /><TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" Grid.Column=\"1\" Grid.Row=\"$repint$\" />",
+                IfReadOnly = false,
+            });
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void FilterMethodsByName()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+
+        Public Async Sub OtherMethodNamez(ByVal name As String, ByVal amount As Integer)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "$nooutput$";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "e",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "e",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "z",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
+                IfReadOnly = false,
+            });
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_OnPhotoTaken_args\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"ONEPARAM_SwitchTheme_theme\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"NOPARAMS_Redo\" />"
+         + Environment.NewLine + "    <TextBlock Text=\"TWOPARAMS_OtherMethodNamez_name_amount\" />"
+          + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        [TestMethod]
+        public void FallbackIsNotUsedForMethods()
+        {
+            var code = @"
+Namespace tests
+    Class Class1☆
+        Public Sub New()
+            ' Constructor is a method but shouldn't match anything
+        End Sub
+
+        Public Sub OnPhotoTaken(ByVal args As CameraControlEventArgs)
+        End Sub
+
+        Public Sub ZoomIn()
+            Return _zoomService?.ZoomIn()
+        End Sub
+
+        Public Sub Undo()
+        End Sub
+
+        Public Async Sub SwitchTheme(ByVal theme As ElementTheme)
+        End Sub
+
+        Public Async Sub Redo()
+        End Sub
+
+        Public Sub MethodName(ByVal name As String, ByVal amount As Integer)
+        End Sub
+
+        Private Sub DoNotMatchBecausePrivate()
+        End Sub
+
+        Public Function DoNotMatchBecauseOfReturnType() As Integer
+        End Function
+
+        Friend Sub DoNotMatchBecauseInternal()
+        End Sub
+
+        Protected Sub DoNotMatchBecauseProtected()
+        End Sub
+
+        Public Sub DoNotMatchAsGeneric(Of T)()
+        End Sub
+    End Class
+End Namespace
+";
+
+            var expectedOutput = "<StackPanel>"
+         + Environment.NewLine + "</StackPanel>";
+
+            var expected = new ParserOutput
+            {
+                Name = "Class1",
+                Output = expectedOutput,
+                OutputType = ParserOutputType.Class,
+            };
+
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<DoNotOutputForMethods />";
+            this.PositionAtStarShouldProduceExpected(code, expected, profile);
+        }
+
+        private Profile MethodTestProfile()
+        {
+            var profile = TestProfile.CreateEmpty();
+            profile.ClassGrouping = "StackPanel";
+            profile.FallbackOutput = "<TextBlock Text=\"FALLBACK_$name$\" />";
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method()",
+                NameContains = "",
+                Output = "<TextBlock Text=\"NOPARAMS_$method$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"ONEPARAM_$method$_$arg1$\" />",
+                IfReadOnly = false,
+            });
+            profile.Mappings.Add(new Mapping
+            {
+                Type = "method(T,T)",
+                NameContains = "",
+                Output = "<TextBlock Text=\"TWOPARAMS_$method$_$arg1$_$arg2$\" />",
+                IfReadOnly = false,
+            });
+
+            return profile;
+        }
+    }
+}

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
@@ -93,7 +93,7 @@ End Namespace";
             {
                 Name = "MyBoolQ",
                 Output = "<BoolQ />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -113,7 +113,7 @@ End Namespace";
             {
                 Name = "MyBoolQ",
                 Output = "<BoolQ />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -133,7 +133,7 @@ End Namespace";
             {
                 Name = "MyNullableBool",
                 Output = "<NullBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -153,7 +153,7 @@ End Namespace";
             {
                 Name = "MyFqNullableBool",
                 Output = "<NullBool />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, this.NullableTestsProfile);
@@ -182,7 +182,7 @@ End Namespace";
             {
                 Name = "MyListOfNullables",
                 Output = "<LBnull />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicNullableTests.cs
@@ -208,7 +208,7 @@ End Namespace";
 
             var expected = new ParserOutput
             {
-                Name = "MyBool, MyBoolQ and 2 other properties",
+                Name = "MyBool, MyBoolQ and 2 other members",
                 Output = expectedXaml,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicPropertiesTests.cs
@@ -29,7 +29,7 @@ End Class";
             {
                 Name = "Property2",
                 Output = "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -51,7 +51,7 @@ End Class";
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -87,7 +87,7 @@ End Namespace";
             {
                 Name = "Property2",
                 Output = "<TextBox Text=\"{x:Bind Property2, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -123,7 +123,7 @@ End Namespace";
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -155,7 +155,7 @@ End Namespace";
             {
                 Name = "Property2",
                 Output = "<TextBlock Text=\"Property2\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -173,7 +173,7 @@ End Class";
             {
                 Name = "SomeProperty",
                 Output = "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"SomeProperty\" Value=\"{x:Bind SomeProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -196,7 +196,7 @@ End Namespace";
                 Name = "MyListProperty",
                 Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\">" + Environment.NewLine +
                          "</ItemsControl>",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -260,7 +260,7 @@ End Namespace";
                 Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty}\">" + Environment.NewLine +
                          "    <TextBlock Text=\"SUBPROP_OtherListProperty\" />" + Environment.NewLine +
                          "</ItemsControl>",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             await this.PositionAtStarShouldProduceExpectedUsingAdditionalFiles(codeFile1, expected, testProfile, codeFile2, codeFile3);
@@ -293,7 +293,7 @@ End Namespace";
                 Name = "MyListProperty2",
                 Output = "<ItemsControl ItemsSource=\"{x:Bind MyListProperty2}\">" + Environment.NewLine +
                          "</ItemsControl>",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -311,7 +311,7 @@ End Class";
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -329,7 +329,7 @@ End Class";
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -347,7 +347,7 @@ End Class";
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -367,7 +367,7 @@ End Namespace";
             {
                 Name = "TestProperty",
                 Output = "<TextBox Text=\"{x:Bind TestProperty, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -393,7 +393,7 @@ End Namespace";
                 Name = "LastOrder",
                 Output = @"<Slider Minimum=""0"" Maximum=""100"" x:Name=""LastOrder.OrderId"" Value=""{x:Bind LastOrder.OrderId, Mode=TwoWay}"" />"
  + Environment.NewLine + @"<TextBox Text=""{x:Bind LastOrder.OrderDescription, Mode=TwoWay}"" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -431,7 +431,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:Array=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, arrayProfile);
@@ -469,7 +469,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:DneType=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, dneProfile);
@@ -498,7 +498,7 @@ End Namespace";
                 Name = "LastOrder",
                 Output = "<Slider Minimum=\"0\" Maximum=\"100\" x:Name=\"LastOrder.OrderId\" Value=\"{x:Bind LastOrder.OrderId, Mode=TwoWay}\" />"
  + Environment.NewLine + "<TextBox Text=\"{x:Bind LastOrder.OrderDescription, Mode=TwoWay}\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             await this.PositionAtStarShouldProduceExpectedUsingAdditionalFiles(code, expected, additionalCode: code2);
@@ -518,7 +518,7 @@ End Namespace";
             {
                 Name = "SomeProperty",
                 Output = "<TextBlock Text=\"FALLBACK_SomeProperty\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected);
@@ -561,7 +561,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = "<TextBlock Text=\"LastOrder\" x:Order=\"true\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, orderProfile);
@@ -613,7 +613,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -664,7 +664,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -715,7 +715,7 @@ End Namespace";
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, enumProfile);
@@ -764,7 +764,7 @@ End Namespace";
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, enumProfile);
@@ -818,7 +818,7 @@ End Namespace";
             {
                 Name = "OrderStatus",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             await this.PositionAtStarShouldProduceExpectedUsingAdditionalFiles(code, expected, enumProfile, code2);
@@ -860,7 +860,7 @@ End Namespace";
             {
                 Name = "LastOrder",
                 Output = expectedOutput,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, recurseProfile);
@@ -889,7 +889,7 @@ End Namespace";
             {
                 Name = "SomeProperty",
                 Output = "<Dynamic Name=\"SomeProperty\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -924,7 +924,7 @@ End Namespace";
             {
                 Name = "SomeList",
                 Output = expectedXaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -1003,7 +1003,7 @@ End Namespace";
             {
                 Name = "ViewModel",
                 Output = "<Element Name=\"ViewModel\" />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);
@@ -1219,7 +1219,7 @@ End Namespace";
             {
                 Name = "IgNoRe",
                 Output = xaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.PositionAtStarShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
@@ -50,7 +50,7 @@ End Namespace";
 
             var expected = new ParserOutput
             {
-                Name = "Property1, Property2 and 6 other properties",
+                Name = "Property1, Property2 and 6 other members",
                 Output = expectedOutput,
                 OutputType = ParserOutputType.Selection,
             };

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicSelectionTests.cs
@@ -224,23 +224,6 @@ End Namespace";
         }
 
         [TestMethod]
-        public void GetSelectionNothingFoundOverMethod()
-        {
-            var code = @"
-Namespace tests
-    Public Class SomeClass
-        Public ReadOnly Property Property2 As String
-
-      ☆  Public Function IsSpecial(someValue As String) As Boolean
-            Return True
-        End Function☆
-    End Class
-End Namespace";
-
-            this.NoPropertiesFoundInSelectionTest(code);
-        }
-
-        [TestMethod]
         public void GetSelectionNothingFoundOverConstructor()
         {
             var code = @"

--- a/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicStructsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Parsers/GetVisualBasicStructsTests.cs
@@ -82,7 +82,7 @@ End Namespace";
             {
                 Name = "Property2",
                 Output = "<MyStruct />",
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);
@@ -134,7 +134,7 @@ End Namespace";
             {
                 Name = "MyListProperty",
                 Output = expectedXaml,
-                OutputType = ParserOutputType.Property,
+                OutputType = ParserOutputType.Member,
             };
 
             this.EachPositionBetweenStarsShouldProduceExpected(code, expected, profile);

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Misc\MiscRealWorldTests.cs" />
     <Compile Include="Parsers\CSharpTestsBase.cs" />
     <Compile Include="Parsers\GetCSharpAttributesTests.cs" />
+    <Compile Include="Parsers\GetVisualBasicMethodsTests.cs" />
     <Compile Include="Parsers\GetCSharpMethodsTests.cs" />
     <Compile Include="Parsers\GetVisualBasicAttributeTypeTests.cs" />
     <Compile Include="Parsers\GetCSharpAttributeTypeTests.cs" />

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Misc\MiscRealWorldTests.cs" />
     <Compile Include="Parsers\CSharpTestsBase.cs" />
     <Compile Include="Parsers\GetCSharpAttributesTests.cs" />
+    <Compile Include="Parsers\GetCSharpMethodsTests.cs" />
     <Compile Include="Parsers\GetVisualBasicAttributeTypeTests.cs" />
     <Compile Include="Parsers\GetCSharpAttributeTypeTests.cs" />
     <Compile Include="Parsers\GetVisualBasicArrayTests.cs" />

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -390,7 +390,7 @@ namespace RapidXamlToolkit.Parsers
                 IsReadOnly = propIsReadOnly ?? false,
             };
 
-            pd.Attributes.AddRange(this.GetAttributes(attributeList));
+            pd.Attributes.AddRange(this.GetAttributeDetails(attributeList));
 
             Logger?.RecordInfo(StringRes.Info_IdentifiedPropertySummary.WithParams(pd.Name, pd.PropertyType, pd.IsReadOnly));
 
@@ -425,7 +425,7 @@ namespace RapidXamlToolkit.Parsers
                     }
                 }
 
-                md.Attributes.AddRange(this.GetAttributes(methodDec.AttributeLists));
+                md.Attributes.AddRange(this.GetAttributeDetails(methodDec.AttributeLists));
             }
             else
             {
@@ -435,7 +435,7 @@ namespace RapidXamlToolkit.Parsers
             return md;
         }
 
-        protected IEnumerable<AttributeDetails> GetAttributes(SyntaxList<AttributeListSyntax> attributeList)
+        protected IEnumerable<AttributeDetails> GetAttributeDetails(SyntaxList<AttributeListSyntax> attributeList)
         {
             var result = new List<AttributeDetails>();
 
@@ -574,8 +574,6 @@ namespace RapidXamlToolkit.Parsers
 
                 if (prop.Type is GenericNameSyntax gns)
                 {
-                    var t = gns.TypeArgumentList.Arguments.First();
-
                     typeSymbol = this.GetTypeSymbolWithFallback(gns, semModel, prop.SyntaxTree);
                 }
                 else if (prop.Type is QualifiedNameSyntax qns)

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -191,7 +191,7 @@ namespace RapidXamlToolkit.Parsers
             return result;
         }
 
-        public override List<MethodDetails> GetAllMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
+        public override List<MethodDetails> GetAllPublicVoidMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
         {
             var methods = new List<ISymbol>();
 
@@ -210,6 +210,8 @@ namespace RapidXamlToolkit.Parsers
                                     .Where(
                                         m => m.Kind == SymbolKind.Method
                                           && m.DeclaredAccessibility == Accessibility.Public
+                                          && ((IMethodSymbol)m).ReturnsVoid
+                                          && !((IMethodSymbol)m).IsGenericMethod
                                           && !m.MetadataName.StartsWith("get_")
                                           && !m.MetadataName.StartsWith("set_")
                                           && !m.IsStatic));

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -74,7 +74,7 @@ namespace RapidXamlToolkit.Parsers
 
             if (propertyNames.Any())
             {
-                var outputName = GetSelectionPropertiesName(propertyNames);
+                var outputName = GetSelectionMemberName(propertyNames);
 
                 Logger?.RecordInfo(StringRes.Info_ReturningOutput.WithParams(outputName));
 

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -304,6 +304,24 @@ namespace RapidXamlToolkit.Parsers
             return pd;
         }
 
+        protected override MethodDetails GetMethodDetails(SyntaxNode methodDeclaration, SemanticModel semModel)
+        {
+            var md = new MethodDetails();
+
+            if (methodDeclaration is MethodDeclarationSyntax methodDec)
+            {
+                md.Name = methodDec.Identifier.ValueText;
+
+                // TODO: get attributes too
+            }
+            else
+            {
+                // TODO: Log error
+            }
+
+            return md;
+        }
+
         protected IEnumerable<AttributeDetails> GetAttributes(SyntaxList<AttributeListSyntax> attributeList)
         {
             var result = new List<AttributeDetails>();
@@ -380,33 +398,36 @@ namespace RapidXamlToolkit.Parsers
             return syntaxNode?.ChildTokens().FirstOrDefault(t => t.Kind() is SyntaxKind.IdentifierToken).ValueText;
         }
 
-        protected override (SyntaxNode propertyNode, SyntaxNode classNode) GetNodeUnderCaret(SyntaxNode documentRoot, int caretPosition)
+        protected override (SyntaxNode propertyNode, SyntaxNode classNode, SyntaxNode methodNode) GetNodeUnderCaret(SyntaxNode documentRoot, int caretPosition)
         {
             PropertyDeclarationSyntax propertyNode = null;
             TypeDeclarationSyntax classNode = null;
+            MethodDeclarationSyntax methodNode = null;
             var currentNode = documentRoot.FindToken(caretPosition).Parent;
 
-            while (currentNode != null && propertyNode == null && classNode == null)
+            while (currentNode != null && propertyNode == null && classNode == null && methodNode == null)
             {
-                if (currentNode is ClassDeclarationSyntax)
+                if (currentNode is ClassDeclarationSyntax cds)
                 {
-                    classNode = currentNode as ClassDeclarationSyntax;
+                    classNode = cds;
                 }
-
-                if (currentNode is StructDeclarationSyntax)
+                else if (currentNode is StructDeclarationSyntax sds)
                 {
-                    classNode = currentNode as StructDeclarationSyntax;
+                    classNode = sds;
                 }
-
-                if (currentNode is PropertyDeclarationSyntax)
+                else if (currentNode is PropertyDeclarationSyntax pds)
                 {
-                    propertyNode = currentNode as PropertyDeclarationSyntax;
+                    propertyNode = pds;
+                }
+                else if (currentNode is MethodDeclarationSyntax mds)
+                {
+                    methodNode = mds;
                 }
 
                 currentNode = currentNode.Parent;
             }
 
-            return (propertyNode, classNode);
+            return (propertyNode, classNode, methodNode);
         }
 
         private ITypeSymbol GetTypeSymbolWithFallback(TypeSyntax ts, SemanticModel sm, SyntaxTree tree)

--- a/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CSharpParser.cs
@@ -312,6 +312,22 @@ namespace RapidXamlToolkit.Parsers
             {
                 md.Name = methodDec.Identifier.ValueText;
 
+                if (methodDec.ParameterList.Parameters.Count > 0)
+                {
+                    var param1 = methodDec.ParameterList.Parameters.First();
+
+                    md.Argument1Name = param1.Identifier.ValueText;
+                    md.Argument1Type = this.GetTypeSymbolWithFallback(param1.Type, semModel, methodDec.SyntaxTree);
+
+                    if (methodDec.ParameterList.Parameters.Count > 1)
+                    {
+                        var param2 = methodDec.ParameterList.Parameters[1];
+
+                        md.Argument2Name = param2.Identifier.ValueText;
+                        md.Argument2Type = this.GetTypeSymbolWithFallback(param2.Type, semModel, methodDec.SyntaxTree);
+                    }
+                }
+
                 // TODO: get attributes too
             }
             else

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -463,7 +463,32 @@ namespace RapidXamlToolkit.Parsers
                                       .Replace(Placeholder.Argument1, arg1)
                                       .Replace(Placeholder.Argument2, arg2);
 
-                // TODO: add grid support and counter replacement
+                var currentNumber = numericSubstitute;
+
+                while (result.Contains(Placeholder.IncrementingInteger))
+                {
+                    Logger?.RecordInfo(StringRes.Info_ReplacingIncIntPlaceholder);
+
+                    var subPosition = result.IndexOf(Placeholder.IncrementingInteger, StringComparison.OrdinalIgnoreCase);
+
+                    result = result.Remove(subPosition, Placeholder.IncrementingInteger.Length);
+                    result = result.Insert(subPosition, numericSubstitute.ToString());
+
+                    numericSubstitute += 1;
+
+                    currentNumber = numericSubstitute - 1;
+                }
+
+                while (result.Contains(Placeholder.RepeatingInteger))
+                {
+                    Logger?.RecordInfo(StringRes.Info_ReplacingRepIntPlaceholder);
+
+                    var subPosition = result.IndexOf(Placeholder.RepeatingInteger, StringComparison.OrdinalIgnoreCase);
+
+                    result = result.Remove(subPosition, Placeholder.RepeatingInteger.Length);
+                    result = result.Insert(subPosition, currentNumber.ToString());
+                }
+
                 var finalResult = result.FormatXaml(CodeParserBase.XamlIndentSize);
 
                 return (finalResult, numericSubstitute);

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -59,7 +59,7 @@ namespace RapidXamlToolkit.Parsers
             return configuredSettings.ActualSettings;
         }
 
-        public static string GetSelectionPropertiesName(List<string> names)
+        public static string GetSelectionMemberName(List<string> names)
         {
             if (names == null || !names.Any())
             {

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -141,7 +141,7 @@ namespace RapidXamlToolkit.Parsers
                 var classTypeSymbol = (ITypeSymbol)semModel.GetDeclaredSymbol(classNode);
                 var properties = this.GetAllPublicProperties(classTypeSymbol, semModel);
 
-                var methods = this.GetAllMethods(classTypeSymbol, semModel);
+                var methods = this.GetAllPublicVoidMethods(classTypeSymbol, semModel);
 
                 var output = new StringBuilder();
 
@@ -245,7 +245,7 @@ namespace RapidXamlToolkit.Parsers
             return new List<PropertyDetails>();
         }
 
-        public virtual List<MethodDetails> GetAllMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
+        public virtual List<MethodDetails> GetAllPublicVoidMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
         {
             return new List<MethodDetails>();
         }

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -1017,11 +1017,17 @@ namespace RapidXamlToolkit.Parsers
                     return mappingOfInterest;
                 }
             }
+            else
+            {
+                return typeMappings.FirstOrDefault(
+                        m => method.Name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                          && m.Type.ToLowerInvariant().Contains("method()"))
+                    ?? typeMappings.FirstOrDefault(
+                        m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                          && m.Type.ToLowerInvariant().Contains("method()"));
+            }
 
-            return typeMappings.FirstOrDefault(
-                    m => method.Name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty))
-                ?? typeMappings.FirstOrDefault(
-                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty));
+            return null;
         }
     }
 }

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -906,13 +906,18 @@ namespace RapidXamlToolkit.Parsers
             return mappingOfInterest;
         }
 
-        private Mapping FirstWithTwoTypes(List<Mapping> mappings, string typeName1, string typeName2)
+        private Mapping FirstWithTwoTypes(List<Mapping> mappings, string methodName, string typeName1, string typeName2)
         {
             // Both types set explicitly
             // With or without space
             var mappingOfInterest = mappings.FirstOrDefault(
-                    m => m.Type.EndsWith($"({typeName1},{typeName2})")
-                      || m.Type.EndsWith($"({typeName1}, {typeName2})"));
+                    m => methodName.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"({typeName1},{typeName2})")
+                      || m.Type.EndsWith($"({typeName1}, {typeName2})")))
+                ?? mappings.FirstOrDefault(
+                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"({typeName1},{typeName2})")
+                      || m.Type.EndsWith($"({typeName1}, {typeName2})")));
 
             if (mappingOfInterest != null)
             {
@@ -921,7 +926,11 @@ namespace RapidXamlToolkit.Parsers
 
             // first anything, second explicit
             mappingOfInterest = mappings.FirstOrDefault(
-                    m => m.Type.EndsWith($"(T,{typeName2})") || m.Type.EndsWith($"(T, {typeName2})"));
+                    m => methodName.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"(T,{typeName2})") || m.Type.EndsWith($"(T, {typeName2})")))
+                ?? mappings.FirstOrDefault(
+                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"(T,{typeName2})") || m.Type.EndsWith($"(T, {typeName2})")));
 
             if (mappingOfInterest != null)
             {
@@ -930,7 +939,11 @@ namespace RapidXamlToolkit.Parsers
 
             // Second anything, first explicit
             mappingOfInterest = mappings.FirstOrDefault(
-                    m => m.Type.EndsWith($"({typeName1},T)") || m.Type.EndsWith($"({typeName1}, T)"));
+                    m => methodName.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"({typeName1},T)") || m.Type.EndsWith($"({typeName1}, T)")))
+                ?? mappings.FirstOrDefault(
+                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"({typeName1},T)") || m.Type.EndsWith($"({typeName1}, T)")));
 
             if (mappingOfInterest != null)
             {
@@ -939,7 +952,11 @@ namespace RapidXamlToolkit.Parsers
 
             // Both anything
             mappingOfInterest = mappings.FirstOrDefault(
-                m => m.Type.EndsWith($"(T,T)") || m.Type.EndsWith($"(T, T)"));
+                    m => methodName.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"(T,T)") || m.Type.EndsWith($"(T, T)")))
+                ?? mappings.FirstOrDefault(
+                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                      && (m.Type.EndsWith($"(T,T)") || m.Type.EndsWith($"(T, T)")));
 
             if (mappingOfInterest != null)
             {
@@ -968,22 +985,32 @@ namespace RapidXamlToolkit.Parsers
                 var arg1TypeName = method.Argument1Type.Name.ToLowerInvariant();
                 var arg2TypeName = method.Argument2Type.Name.ToLowerInvariant();
 
-                return this.FirstWithTwoTypes(typeMappings, arg1TypeName, arg2TypeName);
+                return this.FirstWithTwoTypes(typeMappings, method.Name, arg1TypeName, arg2TypeName);
             }
             else if (!string.IsNullOrWhiteSpace(method.Argument1Type?.Name))
             {
                 var arg1TypeName = method.Argument1Type.Name.ToLowerInvariant();
 
-                var mappingOfInterest = typeMappings.FirstOrDefault(
-                        m => m.Type.Contains($"]method({arg1TypeName})") || m.Type.Equals($"method({arg1TypeName})"));
+                var mappingOfInterest =
+                     typeMappings.FirstOrDefault(
+                         m => method.Name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                           && (m.Type.Contains($"]method({arg1TypeName})") || m.Type.Equals($"method({arg1TypeName})")))
+                     ?? typeMappings.FirstOrDefault(
+                         m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                           && (m.Type.Contains($"]method({arg1TypeName})") || m.Type.Equals($"method({arg1TypeName})")));
 
                 if (mappingOfInterest != null)
                 {
                     return mappingOfInterest;
                 }
 
-                mappingOfInterest = typeMappings.FirstOrDefault(
-                        m => m.Type.Contains($"]method(T)") || m.Type.Equals($"method(T)"));
+                mappingOfInterest =
+                    typeMappings.FirstOrDefault(
+                        m => method.Name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                          && (m.Type.Contains($"]method(T)") || m.Type.Equals($"method(T)")))
+                    ?? typeMappings.FirstOrDefault(
+                        m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty)
+                          && (m.Type.Contains($"]method(T)") || m.Type.Equals($"method(T)")));
 
                 if (mappingOfInterest != null)
                 {
@@ -991,7 +1018,10 @@ namespace RapidXamlToolkit.Parsers
                 }
             }
 
-            return typeMappings.First();
+            return typeMappings.FirstOrDefault(
+                    m => method.Name.ToLowerInvariant().ContainsAnyOf(m?.NameContains?.ToLowerInvariant() ?? string.Empty))
+                ?? typeMappings.FirstOrDefault(
+                    m => string.IsNullOrWhiteSpace(m?.NameContains?.ToLowerInvariant() ?? string.Empty));
         }
     }
 }

--- a/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/CodeParserBase.cs
@@ -141,6 +141,8 @@ namespace RapidXamlToolkit.Parsers
                 var classTypeSymbol = (ITypeSymbol)semModel.GetDeclaredSymbol(classNode);
                 var properties = this.GetAllPublicProperties(classTypeSymbol, semModel);
 
+                var methods = this.GetAllMethods(classTypeSymbol, semModel);
+
                 var output = new StringBuilder();
 
                 var classGrouping = this.Profile.ClassGrouping;
@@ -150,7 +152,7 @@ namespace RapidXamlToolkit.Parsers
                     output.AppendLine($"<{FormattedClassGroupingOpener(classGrouping)}>");
                 }
 
-                if (properties.Any())
+                if (properties.Any() || methods.Any())
                 {
                     Logger?.RecordInfo(StringRes.Info_ClassPropertyCount.WithParams(properties.Count));
 
@@ -162,6 +164,15 @@ namespace RapidXamlToolkit.Parsers
                     {
                         Logger?.RecordInfo(StringRes.Info_AddingPropertyToOutput.WithParams(prop.Name));
                         var toAdd = this.GetOutputToAdd(semModel, prop, numericCounter);
+
+                        numericCounter = toAdd.counter;
+                        propertyOutput.Add(toAdd.output);
+                    }
+
+                    foreach (var method in methods)
+                    {
+                        Logger?.RecordInfo(StringRes.Info_AddingPropertyToOutput.WithParams(method.Name));
+                        var toAdd = this.GetOutputToAdd(semModel, method, numericCounter);
 
                         numericCounter = toAdd.counter;
                         propertyOutput.Add(toAdd.output);
@@ -229,6 +240,11 @@ namespace RapidXamlToolkit.Parsers
         public virtual List<PropertyDetails> GetAllPublicProperties(ITypeSymbol typeSymbol, SemanticModel semModel)
         {
             return new List<PropertyDetails>();
+        }
+
+        public virtual List<MethodDetails> GetAllMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
+        {
+            return new List<MethodDetails>();
         }
 
         protected static string FormattedClassGroupingOpener(string classGrouping)

--- a/VSIX/RapidXamlToolkit/Parsers/MemberDetails.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/MemberDetails.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+
+namespace RapidXamlToolkit.Parsers
+{
+    public class MemberDetails
+    {
+        public MemberDetails(TypeOfMember type)
+        {
+            this.TypeOfMember = type;
+        }
+
+        public static MemberDetails Empty => new MemberDetails(TypeOfMember.None)
+        {
+            Name = string.Empty,
+        };
+
+        public string Name { get; set; }
+
+        public List<AttributeDetails> Attributes { get; set; } = new List<AttributeDetails>();
+
+        public TypeOfMember TypeOfMember { get; set; }
+    }
+}

--- a/VSIX/RapidXamlToolkit/Parsers/MemberType.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/MemberType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace RapidXamlToolkit.Parsers
+{
+    public enum TypeOfMember
+    {
+        None,
+        Property,
+        Method,
+    }
+}

--- a/VSIX/RapidXamlToolkit/Parsers/MethodDetails.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/MethodDetails.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.CodeAnalysis;
+
 namespace RapidXamlToolkit.Parsers
 {
     public class MethodDetails : MemberDetails
@@ -26,6 +28,10 @@ namespace RapidXamlToolkit.Parsers
 
         public string Argument1Name { get; set; }
 
+        public ITypeSymbol Argument1Type { get; set; }
+
         public string Argument2Name { get; set; }
+
+        public ITypeSymbol Argument2Type { get; set; }
     }
 }

--- a/VSIX/RapidXamlToolkit/Parsers/MethodDetails.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/MethodDetails.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace RapidXamlToolkit.Parsers
+{
+    public class MethodDetails : MemberDetails
+    {
+        public MethodDetails()
+            : base(TypeOfMember.Method)
+        {
+        }
+
+        public static new MethodDetails Empty
+        {
+            get
+            {
+                var empty = new MethodDetails
+                {
+                    Name = MemberDetails.Empty.Name,
+                    TypeOfMember = TypeOfMember.Method,
+                };
+
+                return empty;
+            }
+        }
+
+        public string Argument1Name { get; set; }
+
+        public string Argument2Name { get; set; }
+    }
+}

--- a/VSIX/RapidXamlToolkit/Parsers/ParserOutputType.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/ParserOutputType.cs
@@ -6,7 +6,7 @@ namespace RapidXamlToolkit.Parsers
     public enum ParserOutputType
     {
         None,
-        Property,
+        Member,
         Class,
         Selection,
     }

--- a/VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/PropertyDetails.cs
@@ -1,29 +1,38 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace RapidXamlToolkit.Parsers
 {
-    public class PropertyDetails
+    public class PropertyDetails : MemberDetails
     {
-        public static PropertyDetails Empty => new PropertyDetails()
+        public PropertyDetails()
+            : base(TypeOfMember.Property)
         {
-            Name = string.Empty,
-            PropertyType = string.Empty,
-            IsReadOnly = false,
-            Symbol = null,
-        };
+        }
 
-        public string Name { get; set; }
+        public static new PropertyDetails Empty
+        {
+            get
+            {
+                var empty = new PropertyDetails
+                {
+                    Name = MemberDetails.Empty.Name,
+                    TypeOfMember = TypeOfMember.Property,
+                    PropertyType = string.Empty,
+                    IsReadOnly = false,
+                    Symbol = null,
+                };
+
+                return empty;
+            }
+        }
 
         public string PropertyType { get; set; }
 
         public bool IsReadOnly { get; set; }
 
         public ITypeSymbol Symbol { get; set; }
-
-        public List<AttributeDetails> Attributes { get; set; } = new List<AttributeDetails>();
     }
 }

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -80,7 +80,7 @@ namespace RapidXamlToolkit.Parsers
 
             if (propertyNames.Any())
             {
-                var outputName = GetSelectionPropertiesName(propertyNames);
+                var outputName = GetSelectionMemberName(propertyNames);
 
                 Logger?.RecordInfo(StringRes.Info_ReturningOutput.WithParams(outputName));
 

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -424,10 +424,11 @@ namespace RapidXamlToolkit.Parsers
             return syntaxNode?.ChildTokens().FirstOrDefault(t => t.RawKind == (int)SyntaxKind.IdentifierToken).ValueText;
         }
 
-        protected override (SyntaxNode propertyNode, SyntaxNode classNode) GetNodeUnderCaret(SyntaxNode documentRoot, int caretPosition)
+        protected override (SyntaxNode propertyNode, SyntaxNode classNode, SyntaxNode methodNode) GetNodeUnderCaret(SyntaxNode documentRoot, int caretPosition)
         {
             SyntaxNode propertyNode = null;
             SyntaxNode classNode = null;
+            SyntaxNode methodNode = null;
 
             var currentNode = documentRoot.FindToken(caretPosition).Parent;
 
@@ -437,16 +438,19 @@ namespace RapidXamlToolkit.Parsers
                 {
                     classNode = currentNode;
                 }
-
-                if (currentNode is PropertyStatementSyntax || currentNode is PropertyBlockSyntax)
+                else if (currentNode is PropertyStatementSyntax || currentNode is PropertyBlockSyntax)
                 {
                     propertyNode = currentNode;
+                }
+                else if (currentNode is MethodStatementSyntax || currentNode is MethodBlockSyntax)
+                {
+                    methodNode = currentNode;
                 }
 
                 currentNode = currentNode.Parent;
             }
 
-            return (propertyNode, classNode);
+            return (propertyNode, classNode, methodNode);
         }
 
         private ITypeSymbol GetTypeSymbol(SemanticModel semModel, SyntaxNode prop, PropertyDetails propDetails)

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -44,11 +44,27 @@ namespace RapidXamlToolkit.Parsers
 
             Logger?.RecordInfo(StringRes.Info_PropertiesInSelectedAreaCount.WithParams(propertiesOfInterest.Count));
 
+            var allMethods = documentRoot.DescendantNodes().OfType<MethodStatementSyntax>().ToList();
+
+            Logger?.RecordInfo(StringRes.Info_DocumentMethodCount.WithParams(allMethods.Count));
+
+            var methodsOfInterest = new List<MethodStatementSyntax>();
+
+            foreach (var method in allMethods)
+            {
+                if (method.FullSpan.End >= selStart && method.FullSpan.Start < selEnd)
+                {
+                    methodsOfInterest.Add(method);
+                }
+            }
+
+            Logger?.RecordInfo(StringRes.Info_MethodsInSelectedAreaCount.WithParams(methodsOfInterest.Count));
+
             var output = new StringBuilder();
 
             var numericCounter = 1;
 
-            var propertyNames = new List<string>();
+            var memberNames = new List<string>();
 
             foreach (var prop in propertiesOfInterest)
             {
@@ -74,13 +90,29 @@ namespace RapidXamlToolkit.Parsers
                     numericCounter = toAdd.counter;
                     output.AppendLine(toAdd.output);
 
-                    propertyNames.Add(propDetails.Name);
+                    memberNames.Add(propDetails.Name);
                 }
             }
 
-            if (propertyNames.Any())
+            foreach (var method in methodsOfInterest)
             {
-                var outputName = GetSelectionMemberName(propertyNames);
+                var memberDets = this.GetMethodDetails(method, semModel);
+
+                Logger?.RecordInfo(StringRes.Info_AddingMemberToOutput.WithParams(memberDets.Name));
+                var toAdd = this.GetMethodOutputAndCounter(memberDets, numericCounter, semModel);
+
+                if (!string.IsNullOrWhiteSpace(toAdd.output))
+                {
+                    numericCounter = toAdd.counter;
+                    output.AppendLine(toAdd.output);
+
+                    memberNames.Add(memberDets.Name);
+                }
+            }
+
+            if (memberNames.Any())
+            {
+                var outputName = GetSelectionMemberName(memberNames);
 
                 Logger?.RecordInfo(StringRes.Info_ReturningOutput.WithParams(outputName));
 
@@ -94,7 +126,7 @@ namespace RapidXamlToolkit.Parsers
             }
             else
             {
-                Logger?.RecordInfo(StringRes.Info_NoPropertiesToOutput);
+                Logger?.RecordInfo(StringRes.Info_NoMembersToOutput);
                 return ParserOutput.Empty;
             }
         }
@@ -167,6 +199,71 @@ namespace RapidXamlToolkit.Parsers
                 {
                     Logger?.RecordInfo(StringRes.Info_FoundSubPropertyOfUnknownType.WithParams(prop.Name));
                     result.Add(new PropertyDetails { Name = prop.Name, PropertyType = UnknownOrInvalidTypeName, IsReadOnly = false, Symbol = null });
+                }
+            }
+
+            return result;
+        }
+
+        public override List<MethodDetails> GetAllPublicVoidMethods(ITypeSymbol typeSymbol, SemanticModel semModel)
+        {
+            var methods = new List<ISymbol>();
+
+            foreach (var baseType in typeSymbol.GetSelfAndBaseTypes())
+            {
+                if (baseType.Name.IsOneOf(TypesToSkipWhenCheckingForSubMembers))
+                {
+                    continue;
+                }
+
+                switch (baseType.Kind)
+                {
+                    case SymbolKind.NamedType:
+                        methods.AddRange(
+                            baseType.GetMembers()
+                                    .Where(
+                                        m => m.Kind == SymbolKind.Method
+                                          && m.DeclaredAccessibility == Accessibility.Public
+                                          && ((IMethodSymbol)m).ReturnsVoid
+                                          && !((IMethodSymbol)m).IsGenericMethod
+                                          && !m.MetadataName.StartsWith("get_")
+                                          && !m.MetadataName.StartsWith("set_")
+                                          && !m.IsStatic));
+                        break;
+                    case SymbolKind.ErrorType:
+                        Logger?.RecordInfo(StringRes.Info_CannotGetMethodsForKnownType.WithParams(baseType.Name));
+                        break;
+                }
+            }
+
+            var result = new List<MethodDetails>();
+
+            foreach (var method in methods)
+            {
+                if (((IMethodSymbol)method).MethodKind == MethodKind.Constructor)
+                {
+                    continue;
+                }
+
+                var decRefs = method.OriginalDefinition.DeclaringSyntaxReferences;
+
+                if (decRefs.Any())
+                {
+                    var decRef = decRefs.First();
+
+                    SyntaxNode syntax = decRef.SyntaxTree.GetRoot().DescendantNodes(decRef.Span).OfType<MethodStatementSyntax>().FirstOrDefault();
+
+                    var details = this.GetMethodDetails(syntax, semModel);
+
+                    Logger?.RecordInfo(StringRes.Info_FoundSubProperty.WithParams(details.Name));
+                    result.Add(details);
+                }
+                else
+                {
+                    if (method.Name != ".ctor")
+                    {
+                        Logger?.RecordInfo(StringRes.Info_FoundSubMethodOfUnknownType.WithParams(method.Name));
+                    }
                 }
             }
 
@@ -335,6 +432,41 @@ namespace RapidXamlToolkit.Parsers
             return pd;
         }
 
+        protected override MethodDetails GetMethodDetails(SyntaxNode methodDeclaration, SemanticModel semModel)
+        {
+            var md = new MethodDetails();
+
+            if (methodDeclaration is MethodStatementSyntax methodDec)
+            {
+                md.Name = methodDec.Identifier.ValueText;
+
+                if (methodDec.ParameterList.Parameters.Count > 0)
+                {
+                    var param1 = methodDec.ParameterList.Parameters.First();
+
+                    md.Argument1Name = param1.Identifier.Identifier.Text;
+
+                    md.Argument1Type = this.GetTypeSymbolWithFallback(param1.AsClause.Type, semModel, methodDec.SyntaxTree);
+
+                    if (methodDec.ParameterList.Parameters.Count > 1)
+                    {
+                        var param2 = methodDec.ParameterList.Parameters[1];
+
+                        md.Argument2Name = param2.Identifier.Identifier.Text;
+                        md.Argument2Type = this.GetTypeSymbolWithFallback(param2.AsClause.Type, semModel, methodDec.SyntaxTree);
+                    }
+                }
+
+                md.Attributes.AddRange(this.GetAttributeDetails(methodDec.AttributeLists));
+            }
+            else
+            {
+                Logger?.RecordInfo(StringRes.Info_UnexpectedMethodType.WithParams(methodDeclaration.GetType()));
+            }
+
+            return md;
+        }
+
         protected IEnumerable<AttributeDetails> GetAttributeDetails(SyntaxList<AttributeListSyntax> attributeLists)
         {
             var result = new List<AttributeDetails>();
@@ -432,7 +564,7 @@ namespace RapidXamlToolkit.Parsers
 
             var currentNode = documentRoot.FindToken(caretPosition).Parent;
 
-            while (currentNode != null && propertyNode == null && classNode == null)
+            while (currentNode != null && propertyNode == null && classNode == null && methodNode == null)
             {
                 if (currentNode is ClassBlockSyntax || currentNode is ModuleBlockSyntax || currentNode is TypeStatementSyntax)
                 {
@@ -442,7 +574,7 @@ namespace RapidXamlToolkit.Parsers
                 {
                     propertyNode = currentNode;
                 }
-                else if (currentNode is MethodStatementSyntax || currentNode is MethodBlockSyntax)
+                else if (currentNode is MethodStatementSyntax
                 {
                     methodNode = currentNode;
                 }
@@ -453,29 +585,29 @@ namespace RapidXamlToolkit.Parsers
             return (propertyNode, classNode, methodNode);
         }
 
+        private ITypeSymbol GetTypeSymbolWithFallback(TypeSyntax ts, SemanticModel sm, SyntaxTree tree)
+        {
+            ITypeSymbol result;
+
+            try
+            {
+                result = sm.GetTypeInfo(ts).Type;
+            }
+            catch (Exception)
+            {
+                // By default, the semanticmodel passed into this method is the one for the active document.
+                // If the type is in another file, generate a new model to use to look up the typeinfo. Don't do this by default as it's expensive.
+                var localSemModel = VisualBasicCompilation.Create(string.Empty).AddSyntaxTrees(tree).GetSemanticModel(tree, ignoreAccessibility: true);
+
+                result = localSemModel.GetTypeInfo(ts).Type;
+            }
+
+            return result;
+        }
+
         private ITypeSymbol GetTypeSymbol(SemanticModel semModel, SyntaxNode prop, PropertyDetails propDetails)
         {
             ITypeSymbol typeSymbol = null;
-
-            ITypeSymbol GetWithFallback(TypeSyntax ts, SemanticModel sm, SyntaxTree tree)
-            {
-                ITypeSymbol result;
-
-                try
-                {
-                    result = sm.GetTypeInfo(ts).Type;
-                }
-                catch (Exception)
-                {
-                    // By default, the semanticmodel passed into this method is the one for the active document.
-                    // If the type is in another file, generate a new model to use to look up the typeinfo. Don't do this by default as it's expensive.
-                    var localSemModel = VisualBasicCompilation.Create(string.Empty).AddSyntaxTrees(tree).GetSemanticModel(tree, ignoreAccessibility: true);
-
-                    result = localSemModel.GetTypeInfo(ts).Type;
-                }
-
-                return result;
-            }
 
             if (propDetails.PropertyType.IsGenericTypeName())
             {
@@ -510,7 +642,7 @@ namespace RapidXamlToolkit.Parsers
                     Logger?.RecordInfo(StringRes.Info_PropertyCannotBeAnalyzed.WithParams(prop.ToString()));
                 }
 
-                typeSymbol = GetWithFallback(typeSyntax, semModel, prop.SyntaxTree);
+                typeSymbol = this.GetTypeSymbolWithFallback(typeSyntax, semModel, prop.SyntaxTree);
             }
             else
             {
@@ -529,7 +661,7 @@ namespace RapidXamlToolkit.Parsers
                             clauseType = ancs.Type();
                         }
 
-                        typeSymbol = GetWithFallback(clauseType, semModel, prop.SyntaxTree);
+                        typeSymbol = this.GetTypeSymbolWithFallback(clauseType, semModel, prop.SyntaxTree);
                     }
                     else
                     {
@@ -557,7 +689,7 @@ namespace RapidXamlToolkit.Parsers
                 }
                 else if (prop is PropertyBlockSyntax pbs)
                 {
-                    typeSymbol = GetWithFallback(((SimpleAsClauseSyntax)pbs.PropertyStatement.AsClause).Type, semModel, prop.SyntaxTree);
+                    typeSymbol = this.GetTypeSymbolWithFallback(((SimpleAsClauseSyntax)pbs.PropertyStatement.AsClause).Type, semModel, prop.SyntaxTree);
                 }
                 else
                 {

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -574,7 +574,7 @@ namespace RapidXamlToolkit.Parsers
                 {
                     propertyNode = currentNode;
                 }
-                else if (currentNode is MethodStatementSyntax
+                else if (currentNode is MethodStatementSyntax)
                 {
                     methodNode = currentNode;
                 }

--- a/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
+++ b/VSIX/RapidXamlToolkit/Parsers/VisualBasicParser.cs
@@ -105,7 +105,7 @@ namespace RapidXamlToolkit.Parsers
 
             foreach (var baseType in typeSymbol.GetSelfAndBaseTypes())
             {
-                if (baseType.Name.IsOneOf(TypesToSkipWhenCheckingForSubProperties))
+                if (baseType.Name.IsOneOf(TypesToSkipWhenCheckingForSubMembers))
                 {
                     continue;
                 }

--- a/VSIX/RapidXamlToolkit/Placeholder.cs
+++ b/VSIX/RapidXamlToolkit/Placeholder.cs
@@ -38,6 +38,12 @@ namespace RapidXamlToolkit
 
         public const string RepeatingXName = "$repxname$";
 
+        public const string MethodName = "$method$";
+
+        public const string Argument1 = "$arg1$";
+
+        public const string Argument2 = "$arg2$";
+
         private static List<string> all = null;
 
         public static List<string> All()

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -73,6 +73,9 @@
     <Compile Include="Options\EnumConverter.cs" />
     <Compile Include="Parsers\AttributeArgumentDetails.cs" />
     <Compile Include="Parsers\AttributeDetails.cs" />
+    <Compile Include="Parsers\MemberDetails.cs" />
+    <Compile Include="Parsers\MemberType.cs" />
+    <Compile Include="Parsers\MethodDetails.cs" />
     <Compile Include="ProjectTypeExtensions.cs" />
     <Compile Include="RoslynAnalyzers\CsDependencyPropertyCodeFixProvider.cs" />
     <Compile Include="RoslynAnalyzers\CsExpandAutoPropertiesAnalyzer.cs" />

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -358,6 +358,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Formatting output for method &apos;{0}&apos;.
+        /// </summary>
+        public static string Info_FormattingOutputForMethod {
+            get {
+                return ResourceManager.GetString("Info_FormattingOutputForMethod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Formatting output for non-generic type &apos;{0}&apos;..
         /// </summary>
         public static string Info_FormattingOutputForNonGenericType {
@@ -466,6 +475,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Getting output for a single method..
+        /// </summary>
+        public static string Info_GetSingleMethodOutput {
+            get {
+                return ResourceManager.GetString("Info_GetSingleMethodOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Getting output for a single property..
         /// </summary>
         public static string Info_GetSinglePropertyOutput {
@@ -552,6 +570,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Info_NoEnumMappingFound {
             get {
                 return ResourceManager.GetString("Info_NoEnumMappingFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No mapping found for {0} so no output being generated..
+        /// </summary>
+        public static string Info_NoMappingFoundForMethod {
+            get {
+                return ResourceManager.GetString("Info_NoMappingFoundForMethod", resourceCulture);
             }
         }
         

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -223,6 +223,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot get sub-members for known type &apos;{0}&apos;.
+        /// </summary>
+        public static string Info_CannotGetMethodsForKnownType {
+            get {
+                return ResourceManager.GetString("Info_CannotGetMethodsForKnownType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot get sub-properties for known type &apos;{0}&apos;..
         /// </summary>
         public static string Info_CannotGetPropertiesForKnownType {
@@ -444,6 +453,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Info_FoundPropertyCount {
             get {
                 return ResourceManager.GetString("Info_FoundPropertyCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found sub-method of unknown type: {0}.
+        /// </summary>
+        public static string Info_FoundSubMethodOfUnknownType {
+            get {
+                return ResourceManager.GetString("Info_FoundSubMethodOfUnknownType", resourceCulture);
             }
         }
         
@@ -948,6 +966,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Info_UndoContextMoveStringToResourceFile {
             get {
                 return ResourceManager.GetString("Info_UndoContextMoveStringToResourceFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected method type &apos;{0}&apos; cannot be converted to XAML..
+        /// </summary>
+        public static string Info_UnexpectedMethodType {
+            get {
+                return ResourceManager.GetString("Info_UnexpectedMethodType", resourceCulture);
             }
         }
         

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.Designer.cs
@@ -144,6 +144,15 @@ namespace RapidXamlToolkit.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Adding &apos;{0}&apos; to the output..
         /// </summary>
+        public static string Info_AddingMemberToOutput {
+            get {
+                return ResourceManager.GetString("Info_AddingMemberToOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding &apos;{0}&apos; to the output..
+        /// </summary>
         public static string Info_AddingPropertyToOutput {
             get {
                 return ResourceManager.GetString("Info_AddingPropertyToOutput", resourceCulture);
@@ -273,6 +282,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Info_DetectedProjectType {
             get {
                 return ResourceManager.GetString("Info_DetectedProjectType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Document contains {0} methods..
+        /// </summary>
+        public static string Info_DocumentMethodCount {
+            get {
+                return ResourceManager.GetString("Info_DocumentMethodCount", resourceCulture);
             }
         }
         
@@ -547,6 +565,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} methods within the selection area..
+        /// </summary>
+        public static string Info_MethodsInSelectedAreaCount {
+            get {
+                return ResourceManager.GetString("Info_MethodsInSelectedAreaCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attribute parameter named &apos;{0}&apos; not found..
         /// </summary>
         public static string Info_NamedAttributeParameterNotFound {
@@ -588,6 +615,15 @@ namespace RapidXamlToolkit.Resources {
         public static string Info_NoMappingFoundUsingFallback {
             get {
                 return ResourceManager.GetString("Info_NoMappingFoundUsingFallback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No properties or methods to provide output for..
+        /// </summary>
+        public static string Info_NoMembersToOutput {
+            get {
+                return ResourceManager.GetString("Info_NoMembersToOutput", resourceCulture);
             }
         }
         
@@ -2547,7 +2583,7 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}, {1} and {2} other properties.
+        ///   Looks up a localized string similar to {0}, {1} and {2} other members.
         /// </summary>
         public static string UI_SelectionMoreThanThreeNames {
             get {
@@ -2556,7 +2592,7 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}, {1} and 1 other property.
+        ///   Looks up a localized string similar to {0}, {1} and 1 other member.
         /// </summary>
         public static string UI_SelectionThreeNames {
             get {

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -512,10 +512,10 @@
     <value>Rapid XAML Profile</value>
   </data>
   <data name="UI_SelectionMoreThanThreeNames" xml:space="preserve">
-    <value>{0}, {1} and {2} other properties</value>
+    <value>{0}, {1} and {2} other members</value>
   </data>
   <data name="UI_SelectionThreeNames" xml:space="preserve">
-    <value>{0}, {1} and 1 other property</value>
+    <value>{0}, {1} and 1 other member</value>
   </data>
   <data name="UI_SelectionTwoNames" xml:space="preserve">
     <value>{0} and {1}</value>
@@ -994,13 +994,25 @@
   <data name="Info_UnableToDetermineIfExtendedOutputEnabled" xml:space="preserve">
     <value>Unable to determine if extended output is enabled so assuming it is.</value>
   </data>
+  <data name="Info_AddingMemberToOutput" xml:space="preserve">
+    <value>Adding '{0}' to the output.</value>
+  </data>
+  <data name="Info_DocumentMethodCount" xml:space="preserve">
+    <value>Document contains {0} methods.</value>
+  </data>
   <data name="Info_FormattingOutputForMethod" xml:space="preserve">
     <value>Formatting output for method '{0}'</value>
   </data>
   <data name="Info_GetSingleMethodOutput" xml:space="preserve">
     <value>Getting output for a single method.</value>
   </data>
+  <data name="Info_MethodsInSelectedAreaCount" xml:space="preserve">
+    <value>{0} methods within the selection area.</value>
+  </data>
   <data name="Info_NoMappingFoundForMethod" xml:space="preserve">
     <value>No mapping found for {0} so no output being generated.</value>
+  </data>
+  <data name="Info_NoMembersToOutput" xml:space="preserve">
+    <value>No properties or methods to provide output for.</value>
   </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -994,4 +994,13 @@
   <data name="Info_UnableToDetermineIfExtendedOutputEnabled" xml:space="preserve">
     <value>Unable to determine if extended output is enabled so assuming it is.</value>
   </data>
+  <data name="Info_FormattingOutputForMethod" xml:space="preserve">
+    <value>Formatting output for method '{0}'</value>
+  </data>
+  <data name="Info_GetSingleMethodOutput" xml:space="preserve">
+    <value>Getting output for a single method.</value>
+  </data>
+  <data name="Info_NoMappingFoundForMethod" xml:space="preserve">
+    <value>No mapping found for {0} so no output being generated.</value>
+  </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.en-US.resx
@@ -1015,4 +1015,13 @@
   <data name="Info_NoMembersToOutput" xml:space="preserve">
     <value>No properties or methods to provide output for.</value>
   </data>
+  <data name="Info_CannotGetMethodsForKnownType" xml:space="preserve">
+    <value>Cannot get sub-members for known type '{0}'</value>
+  </data>
+  <data name="Info_FoundSubMethodOfUnknownType" xml:space="preserve">
+    <value>Found sub-method of unknown type: {0}</value>
+  </data>
+  <data name="Info_UnexpectedMethodType" xml:space="preserve">
+    <value>Unexpected method type '{0}' cannot be converted to XAML.</value>
+  </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -512,10 +512,10 @@
     <value>Rapid XAML Profile</value>
   </data>
   <data name="UI_SelectionMoreThanThreeNames" xml:space="preserve">
-    <value>{0}, {1} and {2} other properties</value>
+    <value>{0}, {1} and {2} other members</value>
   </data>
   <data name="UI_SelectionThreeNames" xml:space="preserve">
-    <value>{0}, {1} and 1 other property</value>
+    <value>{0}, {1} and 1 other member</value>
   </data>
   <data name="UI_SelectionTwoNames" xml:space="preserve">
     <value>{0} and {1}</value>
@@ -994,13 +994,25 @@
   <data name="Info_UnableToDetermineIfExtendedOutputEnabled" xml:space="preserve">
     <value>Unable to determine if extended output is enabled so assuming it is.</value>
   </data>
+  <data name="Info_AddingMemberToOutput" xml:space="preserve">
+    <value>Adding '{0}' to the output.</value>
+  </data>
+  <data name="Info_DocumentMethodCount" xml:space="preserve">
+    <value>Document contains {0} methods.</value>
+  </data>
   <data name="Info_FormattingOutputForMethod" xml:space="preserve">
     <value>Formatting output for method '{0}'</value>
   </data>
   <data name="Info_GetSingleMethodOutput" xml:space="preserve">
     <value>Getting output for a single method.</value>
   </data>
+  <data name="Info_MethodsInSelectedAreaCount" xml:space="preserve">
+    <value>{0} methods within the selection area.</value>
+  </data>
   <data name="Info_NoMappingFoundForMethod" xml:space="preserve">
     <value>No mapping found for {0} so no output being generated.</value>
+  </data>
+  <data name="Info_NoMembersToOutput" xml:space="preserve">
+    <value>No properties or methods to provide output for.</value>
   </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -994,4 +994,13 @@
   <data name="Info_UnableToDetermineIfExtendedOutputEnabled" xml:space="preserve">
     <value>Unable to determine if extended output is enabled so assuming it is.</value>
   </data>
+  <data name="Info_FormattingOutputForMethod" xml:space="preserve">
+    <value>Formatting output for method '{0}'</value>
+  </data>
+  <data name="Info_GetSingleMethodOutput" xml:space="preserve">
+    <value>Getting output for a single method.</value>
+  </data>
+  <data name="Info_NoMappingFoundForMethod" xml:space="preserve">
+    <value>No mapping found for {0} so no output being generated.</value>
+  </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Resources/StringRes.resx
+++ b/VSIX/RapidXamlToolkit/Resources/StringRes.resx
@@ -1015,4 +1015,13 @@
   <data name="Info_NoMembersToOutput" xml:space="preserve">
     <value>No properties or methods to provide output for.</value>
   </data>
+  <data name="Info_CannotGetMethodsForKnownType" xml:space="preserve">
+    <value>Cannot get sub-members for known type '{0}'</value>
+  </data>
+  <data name="Info_FoundSubMethodOfUnknownType" xml:space="preserve">
+    <value>Found sub-method of unknown type: {0}</value>
+  </data>
+  <data name="Info_UnexpectedMethodType" xml:space="preserve">
+    <value>Unexpected method type '{0}' cannot be converted to XAML.</value>
+  </data>
 </root>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,15 +1,15 @@
 # Installation
 
 There are multiple installation options available if you don't want to build from source.
-We do not reommend having more than one version of the extension installed in a version of Visual Studio.
+We do not recommend having more than one version of the extension installed in a version of Visual Studio.
 
 ## Preview Release
 
-You can now get an early preview release from the marketplace.
+You can now [get an early preview release from the marketplace](https://marketplace.visualstudio.com/items?itemName=MattLaceyLtd.RapidXamlPreview).
 
 ![Manage Extensions dialog showing preview version in the Search Results](./Assets/install-preview.png)
 
-Please note that the preview release once the official release is avaialble.
+Please note that the [preview release](https://marketplace.visualstudio.com/items?itemName=MattLaceyLtd.RapidXamlPreview) will be removed once the official release is available.
 
 ## Official Releases
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -22,6 +22,22 @@ Mappings are matched in the following order:
 
 If a property matches multiple mappings, there is no guarantee on which will be used.
 
+### Mapping methods
+
+It is possible to create a mapping to generate XAML based on a method.  
+To do this specify the type as `method()`, `method(T)`, or `method(T,T)`. These will match methods that take zero, one, or two parameters of any type. The `T` value can also be replaced with a specific type name to further limit the methods it applies to.  
+Filtering by name or applied attribute works in the same way as for properties.
+
+The following special considerations apply to mappings for methods.
+
+- A mapping type for a method cannot contain multiple method specifications, nor be combined with property types.
+- Only public methods that return `void` can be mapped.
+- Only methods that take fewer than three parameters can be used for XAML generation.
+- The 'Read-Only' setting is ignored for method mappings.
+- The fallback mapping is not applied to methods. XAML will only be generated for methods if a specific mapping is matched.
+- The name of the first argument passed to a method can be output with the placeholder `$arg1$`. For `void LogOut(User user) {}` this would be `user`.
+- The name of the second argument passed to a method can be output with the placeholder `$arg2$`. For `void DoSomething(User user, int operationId) {}` this would be `operationId`.
+
 ### Matching types with attributes
 
 It's possible to use attributes applied to properties to determine what to output. (Attributes can also be used in the output--see below.)
@@ -68,6 +84,9 @@ Profile settings and mappings can include placeholders. A placeholder is somethi
 - **$nooutput$** No Output. Nothing will be included in the generated XAML when this is in the mapping output.
 - **$xname$** A generated value based on the property name and the XAML element this is used within.
 - **$repxname$** Repeat the last generated $xname$ value. If no $xname$ value has been generated, the attribute this is used within will be omitted from the output.
+- **$method$** The name of the method.
+- **$arg1$** The name of the first argument passed to a method (if any).
+- **$arg2$** The name of the second argument passed to a method (if any).
 
 ### Attribute based placeholders
 


### PR DESCRIPTION
This PR relates to Issue #280

Can now generate XAML based on methods and properties.

details at https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/i280-MethodBasedGen/docs/profiles.md#mapping-methods