### PR TITLE
correctly handle method related placeholders in options UI validation

### DIFF
--- a/VSIX/RapidXamlToolkit/Options/Mapping.cs
+++ b/VSIX/RapidXamlToolkit/Options/Mapping.cs
@@ -67,7 +67,7 @@ namespace RapidXamlToolkit.Options
             }
         }
 
-        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.SafePropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.EnumMembers, Placeholder.SubProperties, Placeholder.NoOutput, Placeholder.XName, Placeholder.RepeatingXName)]
+        [AllowedPlaceholders(Placeholder.PropertyName, Placeholder.SafePropertyName, Placeholder.PropertyNameWithSpaces, Placeholder.PropertyType, Placeholder.IncrementingInteger, Placeholder.RepeatingInteger, Placeholder.EnumMembers, Placeholder.SubProperties, Placeholder.NoOutput, Placeholder.XName, Placeholder.RepeatingXName, Placeholder.MethodName, Placeholder.Argument1, Placeholder.Argument2)]
         public string Output
         {
             get


### PR DESCRIPTION
This PR relates to Issue #280

**Description**  
allow method related placeholders to be valid for mapping output in options UI