### PR TITLE
Get string of XAML element without children

### DIFF
--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/InsertRowDefinitionAction.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/InsertRowDefinitionAction.cs
@@ -60,6 +60,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public static Dictionary<int, int> GetExclusions(string xaml)
         {
+            // Find other nested grids
             return XamlElementProcessor.GetExclusions(xaml, Elements.Grid);
         }
 

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/EveryElementProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/EveryElementProcessor.cs
@@ -19,6 +19,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
         public override void Process(string fileName, int offset, string xamlElement, string linePadding, ITextSnapshot snapshot, TagList tags, List<TagSuppression> suppressions = null)
         {
+            // Remove children to avoid getting duplicates when children are processed.
             xamlElement = GetOpeningWithoutChildren(xamlElement);
 
             if (this.TryGetAttribute(xamlElement, Attributes.Uid, AttributeType.InlineOrElement, out _, out int index, out int length, out string value))

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/EveryElementProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/EveryElementProcessor.cs
@@ -19,6 +19,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
         public override void Process(string fileName, int offset, string xamlElement, string linePadding, ITextSnapshot snapshot, TagList tags, List<TagSuppression> suppressions = null)
         {
+            xamlElement = GetOpeningWithoutChildren(xamlElement);
+
             if (this.TryGetAttribute(xamlElement, Attributes.Uid, AttributeType.InlineOrElement, out _, out int index, out int length, out string value))
             {
                 if (!char.IsUpper(value[0]))

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/XamlElementProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/XamlElementProcessor.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.Text;
 using RapidXamlToolkit.Logging;
 using RapidXamlToolkit.XamlAnalysis.Tags;
@@ -135,6 +137,109 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 #endif
 
             return result;
+        }
+
+        public static string GetOpeningWithoutChildren(string xamlElementThatMayHaveChildren)
+        {
+            if (xamlElementThatMayHaveChildren.EndsWith("/>"))
+            {
+                // If self-closing then definitely doesn't have children
+                return xamlElementThatMayHaveChildren;
+            }
+
+            // Don't walk the whole string if we can avoid it for something without any sub-elements
+            if (xamlElementThatMayHaveChildren.Count(x => x == '<') == 2
+             && xamlElementThatMayHaveChildren.Count(x => x == '>') == 2)
+            {
+                return xamlElementThatMayHaveChildren;
+            }
+
+            // Get element name
+
+            // Get all subsequent element openings until find one that doesn't start with elementName + '.'
+
+            var endOfElementName = xamlElementThatMayHaveChildren.FirstIndexOf(" ", "\r", "\n", ">");
+
+            var elementName = xamlElementThatMayHaveChildren.Substring(1, endOfElementName - 1);
+
+            var nextElementStart = xamlElementThatMayHaveChildren.IndexOf('<', endOfElementName);
+
+            var possibleNextElementName = string.Empty;
+
+            while (nextElementStart > 0)
+            {
+                possibleNextElementName = xamlElementThatMayHaveChildren.Substring(nextElementStart + 1, elementName.Length + 1);
+
+                if (!possibleNextElementName.StartsWith(elementName) || possibleNextElementName.EndsWith(" "))
+                {
+                    var stringSoFar = xamlElementThatMayHaveChildren.Substring(0, nextElementStart)
+
+                    var openings = stringSoFar.Count(s => s == '<');
+                    var closings = stringSoFar.OccurrenceCount("</");
+                    var selfClosings = stringSoFar.OccurrenceCount("/>");
+
+                    if ()
+                    {
+                        return stringSoFar;
+                    }
+                }
+
+                nextElementStart = xamlElementThatMayHaveChildren.IndexOf('<', nextElementStart + 1);
+            }
+
+            // Only something unaccounted for above should get here - Give everything as fallback.
+            return xamlElementThatMayHaveChildren;
+
+
+            //var openingElementName = new StringBuilder();
+            //var currentElementBody = new StringBuilder();
+            //var inOpeningElementName = false;
+
+            //var openCount = 0;
+            //var closeCount = 0;
+
+            //var xaml = xamlElementThatMayHaveChildren;
+
+            //for (int i = 0; i < xaml.Length; i++)
+            //{
+            //    currentElementBody.Append(xaml[i]);
+
+            //    if (xaml[i] == '<')
+            //    {
+            //        openCount += 1;
+            //    }
+            //    else if (xaml[i] == '>')
+            //    {
+            //        closeCount += 1;
+
+            //        if (closeCount == openCount)
+            //        {
+            //            break;
+            //        }
+            //    }
+            //    else if (char.IsLetterOrDigit(xaml[i]) || xaml[i] == ':' || xaml[i] == '_' || xaml[i] == '.')
+            //    {
+            //        if (!inOpeningElementName && openingElementName.Length == 0)
+            //        {
+            //            inOpeningElementName = true;
+            //        }
+
+            //        if (inOpeningElementName)
+            //        {
+            //            openingElementName.Append(xaml[i]);
+            //        }
+            //    }
+            //    else if (xaml[i] == '\r' || xaml[i] == '\n' || char.IsWhiteSpace(xaml[i]))
+            //    {
+            //        inOpeningElementName = false;
+            //    }
+
+
+
+
+            //}
+
+            //return currentElementBody.ToString();
         }
 
         /// <summary>

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/XamlElementProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/XamlElementProcessor.cs
@@ -141,6 +141,9 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
         public static string GetOpeningWithoutChildren(string xamlElementThatMayHaveChildren)
         {
+            // Following logic assumes no whitespace at front
+            xamlElementThatMayHaveChildren = xamlElementThatMayHaveChildren.TrimStart();
+
             if (xamlElementThatMayHaveChildren.EndsWith("/>"))
             {
                 // If self-closing then definitely doesn't have children
@@ -151,12 +154,8 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             if (xamlElementThatMayHaveChildren.Count(x => x == '<') == 2
              && xamlElementThatMayHaveChildren.Count(x => x == '>') == 2)
             {
-                return xamlElementThatMayHaveChildren;
+                return xamlElementThatMayHaveChildren.Substring(0, xamlElementThatMayHaveChildren.IndexOf('>') + 1).Trim();
             }
-
-            // Get element name
-
-            // Get all subsequent element openings until find one that doesn't start with elementName + '.'
 
             var endOfElementName = xamlElementThatMayHaveChildren.FirstIndexOf(" ", "\r", "\n", ">");
 
@@ -170,15 +169,17 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
             {
                 possibleNextElementName = xamlElementThatMayHaveChildren.Substring(nextElementStart + 1, elementName.Length + 1);
 
-                if (!possibleNextElementName.StartsWith(elementName) || possibleNextElementName.EndsWith(" "))
+                if (possibleNextElementName != $"{elementName}."
+                    && possibleNextElementName != $"/{elementName}")
                 {
-                    var stringSoFar = xamlElementThatMayHaveChildren.Substring(0, nextElementStart)
+                    var stringSoFar = xamlElementThatMayHaveChildren.Substring(0, nextElementStart);
 
                     var openings = stringSoFar.Count(s => s == '<');
                     var closings = stringSoFar.OccurrenceCount("</");
+                    openings -= closings; // Allow for the openings count incorrectly including closings
                     var selfClosings = stringSoFar.OccurrenceCount("/>");
 
-                    if ()
+                    if (openings == closings + selfClosings + 1)
                     {
                         return stringSoFar;
                     }
@@ -189,57 +190,6 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             // Only something unaccounted for above should get here - Give everything as fallback.
             return xamlElementThatMayHaveChildren;
-
-
-            //var openingElementName = new StringBuilder();
-            //var currentElementBody = new StringBuilder();
-            //var inOpeningElementName = false;
-
-            //var openCount = 0;
-            //var closeCount = 0;
-
-            //var xaml = xamlElementThatMayHaveChildren;
-
-            //for (int i = 0; i < xaml.Length; i++)
-            //{
-            //    currentElementBody.Append(xaml[i]);
-
-            //    if (xaml[i] == '<')
-            //    {
-            //        openCount += 1;
-            //    }
-            //    else if (xaml[i] == '>')
-            //    {
-            //        closeCount += 1;
-
-            //        if (closeCount == openCount)
-            //        {
-            //            break;
-            //        }
-            //    }
-            //    else if (char.IsLetterOrDigit(xaml[i]) || xaml[i] == ':' || xaml[i] == '_' || xaml[i] == '.')
-            //    {
-            //        if (!inOpeningElementName && openingElementName.Length == 0)
-            //        {
-            //            inOpeningElementName = true;
-            //        }
-
-            //        if (inOpeningElementName)
-            //        {
-            //            openingElementName.Append(xaml[i]);
-            //        }
-            //    }
-            //    else if (xaml[i] == '\r' || xaml[i] == '\n' || char.IsWhiteSpace(xaml[i]))
-            //    {
-            //        inOpeningElementName = false;
-            //    }
-
-
-
-
-            //}
-
-            //return currentElementBody.ToString();
         }
 
         /// <summary>

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementProcessorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementProcessorTests.cs
@@ -375,7 +375,7 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         public void GetOpeningWithoutChildren_NoChildren()
         {
             var origin = "<Foo Bar=\"123\"></Foo>";
-            var expected = origin;
+            var expected = "<Foo Bar=\"123\">";
 
             var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
 
@@ -399,7 +399,7 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var origin = "<Foo Bar=\"123\">content</Foo>";
 
-            var expected = origin;
+            var expected = "<Foo Bar=\"123\">";
 
             var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
 
@@ -435,7 +435,7 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
         {
             var origin = "<Foo><Foo.Bar=\"123\" /><Foo.Bar=\"123\" /><FuBar /><FuBar /></Foo>";
 
-            var expected = "";
+            var expected = "<Foo><Foo.Bar=\"123\" /><Foo.Bar=\"123\" />";
 
             var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
 
@@ -448,6 +448,18 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
             var origin = "<Foo><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Fu><Baa /></Fu><FuBar /></Foo>";
 
             var expected = "<Foo><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar>";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_MultipleChildren_AndMultipleAttributesAsElementsWithNesting_PlusAssortedWhitespace()
+        {
+            var origin = "   <Foo>  <Foo.Bar=\"123\">\r\n<Other />\r<Other />\r\n\r\n</Foo.Bar>\r\n<Foo.Bar=\"123\">\r\n    <Other />\r\n    <Other  /></Foo.Bar ><Fu><Baa /></Fu><FuBar  />  </Foo>";
+
+            var expected = "<Foo>  <Foo.Bar=\"123\">\r\n<Other />\r<Other />\r\n\r\n</Foo.Bar>\r\n<Foo.Bar=\"123\">\r\n    <Other />\r\n    <Other  /></Foo.Bar >";
 
             var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
 

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementProcessorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/XamlElementProcessorTests.cs
@@ -360,6 +360,112 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
             Assert.AreEqual(expected, actual);
         }
 
+        [TestMethod]
+        public void GetOpeningWithoutChildren_SelfClosing()
+        {
+            var origin = "<Foo Bar=\"123\" />";
+            var expected = origin;
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_NoChildren()
+        {
+            var origin = "<Foo Bar=\"123\"></Foo>";
+            var expected = origin;
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_OneChild_SameType()
+        {
+            var origin = "<Foo Bar=\"123\"><Foo /></Foo>";
+
+            var expected = "<Foo Bar=\"123\">";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_StringAsChildIncluded()
+        {
+            var origin = "<Foo Bar=\"123\">content</Foo>";
+
+            var expected = origin;
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_OneChild_DifferentType()
+        {
+            var origin = "<Foo Bar=\"123\"><FuBar /></Foo>";
+
+            var expected = "<Foo Bar=\"123\">";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_OneChild_ButAttributeAsElement()
+        {
+            var origin = "<Foo><Foo.Bar=\"123\" /><FuBar /></Foo>";
+
+            var expected = "<Foo><Foo.Bar=\"123\" />";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_MultipleChildren_AndMultipleAttributesAsElements()
+        {
+            var origin = "<Foo><Foo.Bar=\"123\" /><Foo.Bar=\"123\" /><FuBar /><FuBar /></Foo>";
+
+            var expected = "";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_MultipleChildren_AndMultipleAttributesAsElementsWithNesting()
+        {
+            var origin = "<Foo><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Fu><Baa /></Fu><FuBar /></Foo>";
+
+            var expected = "<Foo><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar><Foo.Bar=\"123\"><Other /><Other /></Foo.Bar>";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetOpeningWithoutChildren_MultipleChildren()
+        {
+            var origin = "<Foo Bar=\"123\"><FooItem /><FooItem /></Foo>";
+
+            var expected = "<Foo Bar=\"123\">";
+
+            var actual = XamlElementProcessor.GetOpeningWithoutChildren(origin);
+
+            Assert.AreEqual(expected, actual);
+        }
+
         private string GetSubElementAtStar(string outerElement)
         {
             var offset = outerElement.IndexOf('☆');


### PR DESCRIPTION
This PR relates to Issue #317  (Avoid duplicate tags on nested elements -- via EveryElementProcessor)

**Description**  

Adds helper to get (string representing) XAML element without children.

**Important points of note**  
n/a
