### PR TITLE
Handle files that aren't part of a project

### DIFF
--- a/VSIX/RapidXaml.Shared/VisualStudioIntegration/VisualStudioAbstraction.cs
+++ b/VSIX/RapidXaml.Shared/VisualStudioIntegration/VisualStudioAbstraction.cs
@@ -53,6 +53,11 @@ namespace RapidXamlToolkit.VisualStudioIntegration
             const string XamAndroidGuid = "{EFBA0AD7-5A72-4C68-AF49-83D382785DCF}";
             const string XamIosGuid = "{6BC8ED88-2882-458C-8E55-DFD12B67127B}";
 
+            if (string.IsNullOrWhiteSpace(project?.FileName) || project?.DTE == null)
+            {
+                return ProjectType.Unknown;
+            }
+
             bool ReferencesXamarin(EnvDTE.Project proj)
             {
                 return ReferencesNuGetPackageWithNameContaining(proj, "xamarin");


### PR DESCRIPTION
This PR relates to Issue #366

**Description**  

Discovered as part of testing a file diff. 
A diff can include a temporary copy of a file (in a temp directory) and so is not be part of the active project.

Can (could) get in an infinite loop when a file is not in a project when looking up the error type overrides.