### PR TITLE
Avoid analysis suggestion crash

### DIFF
--- a/Templates/CustomAnalysisItemTemplate/CustomAnalysisItemTemplate.vstemplate
+++ b/Templates/CustomAnalysisItemTemplate/CustomAnalysisItemTemplate.vstemplate
@@ -20,7 +20,7 @@
     </WizardExtension>
     <WizardData>
         <packages>
-            <package id="RapidXaml.CustomAnalysis" version="0.10.1" />
+            <package id="RapidXaml.CustomAnalysis" version="0.10.2" />
         </packages>
     </WizardData>
 </VSTemplate>

--- a/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.csproj
+++ b/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.10.1" />
+        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.10.2" />
     </ItemGroup>
 
 </Project>

--- a/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.nuspec
+++ b/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.nuspec
@@ -13,7 +13,7 @@
         <tags>RapidXaml, XamlAnalyzer</tags>
         <dependencies>
             <group targetFramework="netstandard2.0">
-                <dependency id="RapidXaml.CustomAnalysis" version="0.10.1" exclude="Build,Analyzers" />
+                <dependency id="RapidXaml.CustomAnalysis" version="0.10.2" exclude="Build,Analyzers" />
             </group>
         </dependencies>
     </metadata>

--- a/Templates/CustomAnalysisProjectTemplate/AnalyzerTests/CustomAnalyzerProjectTests.csproj
+++ b/Templates/CustomAnalysisProjectTemplate/AnalyzerTests/CustomAnalyzerProjectTests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.10.1" />
+        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.10.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Templates/RapidXaml.Templates/Properties/AssemblyInfo.cs
+++ b/Templates/RapidXaml.Templates/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/Templates/RapidXaml.Templates/RapidXamlTemplatesPackage.cs
+++ b/Templates/RapidXaml.Templates/RapidXamlTemplatesPackage.cs
@@ -9,7 +9,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace RapidXaml.Templates
 {
-    [InstalledProductRegistration("#110", "#112", "0.10.1")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.10.2")] // Info on this package for Help/About
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(RapidXamlTemplatesPackage.PackageGuidString)]
     public sealed class RapidXamlTemplatesPackage : AsyncPackage

--- a/Templates/RapidXaml.Templates/source.extension.vsixmanifest
+++ b/Templates/RapidXaml.Templates/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Templates</DisplayName>
     <Description xml:space="preserve">Project and item templates to help with XAML development.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]
 
 ////[assembly: InternalsVisibleTo(
 ////    "RapidXamlToolkit.Tests, PublicKey=" +

--- a/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
+++ b/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
@@ -21,7 +21,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UIContextGuids.SolutionHasMultipleProjects, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UIContextGuids.SolutionHasSingleProject, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.10.1")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.10.2")] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(RapidXamlAnalysisPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(AnalysisOptionsGrid), "Rapid XAML", "Analysis", 106, 107, true)]

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/BaseSuggestedAction.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/BaseSuggestedAction.cs
@@ -22,7 +22,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public string DisplayText { get; protected set; }
 
-        public virtual bool IsEnabled { get; } = true;
+        public virtual bool IsEnabled { get; protected set; } = true;
 
         public virtual bool HasActionSets
         {
@@ -72,6 +72,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public void Invoke(CancellationToken cancellationToken)
         {
+            if (!this.IsEnabled)
+            {
+                return;
+            }
+
             var undoContext = ProjectHelpers.Dte2.UndoContext;
 
             try

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/CustomAnalysisAction.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/CustomAnalysisAction.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Windows.Documents;
 using RapidXaml;
 using RapidXamlToolkit.VisualStudioIntegration;
 using RapidXamlToolkit.XamlAnalysis.Processors;
@@ -19,7 +18,16 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
             : base(file)
         {
             this.Tag = tag;
-            this.DisplayText = tag.ActionText;
+
+            if (string.IsNullOrWhiteSpace(tag.ActionText))
+            {
+                this.DisplayText = Resources.StringRes.UI_XamlAnalysisFixUnavailable;
+                this.IsEnabled = false;
+            }
+            else
+            {
+                this.DisplayText = tag.ActionText;
+            }
 
             this.CustomFeatureUsageOverride = tag.CustomFeatureUsageOverride;
         }

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/SuppressWarningAction.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/SuppressWarningAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Threading;
+using RapidXamlToolkit.ErrorList;
 using RapidXamlToolkit.Resources;
 using RapidXamlToolkit.XamlAnalysis.Tags;
 
@@ -36,8 +37,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
         public override void Execute(CancellationToken cancellationToken)
         {
             this.Tag.SetAsHiddenInSettingsFile();
-            RapidXamlDocumentCache.RemoveTags(this.Tag.FileName, this.ErrorCode);
             this.Source.Refresh();
+            RapidXamlDocumentCache.RemoveTags(this.Tag.FileName, this.ErrorCode);
+            RapidXamlDocumentCache.Invalidate(this.Tag.FileName);
+            RapidXamlDocumentCache.TryUpdate(this.Tag.FileName);
+            TableDataSource.Instance.CleanErrors(this.Tag.FileName);
         }
     }
 }

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocumentCache.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocumentCache.cs
@@ -128,7 +128,10 @@ namespace RapidXamlToolkit.XamlAnalysis
         {
             lock (CacheLock)
             {
-                Cache[file].Clear();
+                if (Cache.ContainsKey(file))
+                {
+                    Cache[file].Clear();
+                }
             }
 
             TableDataSource.Instance.CleanErrors(file);

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocumentCache.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocumentCache.cs
@@ -75,7 +75,7 @@ namespace RapidXamlToolkit.XamlAnalysis
                     return VsShellUtilities.IsDocumentOpen(
                         package,
                         path,
-                        VSConstants.LOGVIEWID_TextView,
+                        logicalView,
                         out var dummyHierarchy2,
                         out var dummyItemId2,
                         out windowFrame);
@@ -88,8 +88,8 @@ namespace RapidXamlToolkit.XamlAnalysis
             }
 
             var docIsOpenInTextView =
-                DocIsOpenInLogicalView(file, VSConstants.LOGVIEWID_Code, out var windowFrameForTextView) ||
-                DocIsOpenInLogicalView(file, VSConstants.LOGVIEWID_TextView, out windowFrameForTextView);
+                DocIsOpenInLogicalView(file, VSConstants.LOGVIEWID_TextView, out var windowFrameForTextView) ||
+                DocIsOpenInLogicalView(file, VSConstants.LOGVIEWID_Code, out windowFrameForTextView);
 
             if (docIsOpenInTextView && windowFrameForTextView != null)
             {

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/SuggestedActionsSource.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/SuggestedActionsSource.cs
@@ -136,13 +136,11 @@ namespace RapidXamlToolkit.XamlAnalysis
 
         public IEnumerable<SuggestedActionSet> CreateActionSet(IRapidXamlTag tag, params BaseSuggestedAction[] actions)
         {
-            var enabledActions = actions.Where(action => action.IsEnabled);
-
             var result = new List<SuggestedActionSet>()
             {
                 new SuggestedActionSet(
                     PredefinedSuggestedActionCategoryNames.Refactoring,
-                    actions: enabledActions,
+                    actions: actions,
                     title: StringRes.UI_SuggestedActionSetTitle,
                     priority: SuggestedActionSetPriority.None,
                     applicableToSpan: tag.Span),

--- a/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Analysis</DisplayName>
     <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.10.1</Version>
+    <Version>0.10.2</Version>
   </PropertyGroup>
   <!-- Pack settings -->
   <PropertyGroup>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>RapidXaml.BuildAnalysis</id>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <authors>Matt Lacey</authors>
     <owners>MRLacey</owners>
     <copyright>Copyright © 2020 Matt Lacey Ltd.</copyright>

--- a/VSIX/RapidXaml.Common/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Common/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXaml.Common/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Common/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Common Functionality</DisplayName>
     <Description xml:space="preserve">Common infrastructure used by other extensions that are part of the Rapid XAML Toolkit.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXaml.CustomAnalysis/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.csproj
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.10.1</Version>
+    <Version>0.10.2</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>RapidXaml.CustomAnalysis</id>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <authors>Matt Lacey</authors>
     <owners>MRLacey</owners>
     <license type="expression">MIT</license>

--- a/VSIX/RapidXaml.Generation/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Generation/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXaml.Generation/RapidXamlGenerationPackage.cs
+++ b/VSIX/RapidXaml.Generation/RapidXamlGenerationPackage.cs
@@ -20,7 +20,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UIContextGuids.SolutionHasMultipleProjects, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UIContextGuids.SolutionHasSingleProject, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.10.1")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.10.2")] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(RapidXamlGenerationPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(SettingsConfigPage), "Rapid XAML", "Profiles", 106, 107, true)]

--- a/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Generation</DisplayName>
     <Description xml:space="preserve">Tools to accelerate XAML app development by generating XAML.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXaml.RoslynAnalyzers/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.RoslynAnalyzers/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXaml.RoslynAnalyzers/RapidXamlRoslynAnalyzersPackage.cs
+++ b/VSIX/RapidXaml.RoslynAnalyzers/RapidXamlRoslynAnalyzersPackage.cs
@@ -17,7 +17,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UIContextGuids.SolutionHasSingleProject, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.10.1")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.10.2")] // Info on this package for Help/About
     [Guid(RapidXamlRoslynAnalyzersPackage.PackageGuidString)]
     public sealed class RapidXamlRoslynAnalyzersPackage : AsyncPackage
     {

--- a/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML RoslynAnalyzers</DisplayName>
     <Description xml:space="preserve">Roslyn analyzers to help with XAML app development.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXaml.Shared/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Shared/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXaml.Shared/Resources/StringRes.Designer.cs
+++ b/VSIX/RapidXaml.Shared/Resources/StringRes.Designer.cs
@@ -1683,6 +1683,15 @@ namespace RapidXamlToolkit.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sorry, an automated fix for this issue is not currently available..
+        /// </summary>
+        public static string UI_XamlAnalysisFixUnavailable {
+            get {
+                return ResourceManager.GetString("UI_XamlAnalysisFixUnavailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} contains hard-coded {1} value &apos;{2}&apos;..
         /// </summary>
         public static string UI_XamlAnalysisGenericHardCodedStringDescription {

--- a/VSIX/RapidXaml.Shared/Resources/StringRes.resx
+++ b/VSIX/RapidXaml.Shared/Resources/StringRes.resx
@@ -838,4 +838,7 @@
   <data name="Info_UsedFeatureParseDocument" xml:space="preserve">
     <value>DocumentParsed_TagsFound{0}</value>
   </data>
+  <data name="UI_XamlAnalysisFixUnavailable" xml:space="preserve">
+    <value>Sorry, an automated fix for this issue is not currently available.</value>
+  </data>
 </root>

--- a/VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]

--- a/VSIX/RapidXamlToolkit/RapidXamlPackage.cs
+++ b/VSIX/RapidXamlToolkit/RapidXamlPackage.cs
@@ -12,7 +12,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UIContextGuids.SolutionHasMultipleProjects, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UIContextGuids.SolutionHasSingleProject, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.10.1")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.10.2")] // Info on this package for Help/About
     [Guid(PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     public sealed class RapidXamlPackage : AsyncPackage

--- a/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.10.1" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.10.2" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Toolkit</DisplayName>
     <Description xml:space="preserve">Tools to accelerate XAML app development.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>


### PR DESCRIPTION
This PR relates to Issue #370 
Also fixes #319

**Description**  
Ensure that something is displayed in the suggested actions dropdown even if there's nothing that can be executed.
Hopefully this will avoid an exception that couldn't be recreated.