### PR TITLE
Add checks for Uno platform-specific xmlns are ignored

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ _earlier release notes are summary only and were retrospectively created_
 - Performance improvements.
 - Enabled custom analysis using `AnyOf:`, `AnyContaining:`, and `AnyOrChildrenContaining:` prefixes.
 - Refactoring to support the AutoFix package.
+- Add first Uno specific analyzers.
 
 ## 0.10
 

--- a/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
+++ b/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
@@ -105,6 +105,7 @@
     <Compile Include="XamlAnalysis\CustomAnalysis\CustomGridDefinitionAnalyzer.cs" />
     <Compile Include="XamlAnalysis\CustomAnalysis\Issue364ExampleAnalyzer.cs" />
     <Compile Include="XamlAnalysis\CustomAnalysis\Issue364ExampleAnalyzer2.cs" />
+    <Compile Include="XamlAnalysis\CustomAnalysis\UnoIgnorablesAnalyzer.cs" />
     <Compile Include="XamlAnalysis\CustomAnalysis\XamarinForms\EntryCellAnalyzer.cs" />
     <Compile Include="XamlAnalysis\CustomAnalysis\FooAnalysis.cs" />
     <Compile Include="XamlAnalysis\CustomAnalysis\InternalBadCustomAnalyzer.cs" />

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/CustomAnalysis/UnoIgnorablesAnalyzer.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/CustomAnalysis/UnoIgnorablesAnalyzer.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Matt Lacey Ltd. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Linq;
+using RapidXaml;
+
+namespace RapidXamlToolkit.XamlAnalysis.CustomAnalysis
+{
+    public class UnoIgnorablesAnalyzer : BuiltInXamlAnalyzer
+    {
+        public override string TargetType() => "Page";
+
+        public override AnalysisActions Analyze(RapidXamlElement element, ExtraAnalysisDetails extraDetails)
+        {
+            if (!extraDetails.TryGet("framework", out ProjectFramework framework)
+             || framework != ProjectFramework.Uwp)
+            {
+                return AnalysisActions.None;
+            }
+
+            var result = AnalysisActions.EmptyList;
+
+            var ignorable = element.Attributes.FirstOrDefault(a => a.Name == "mc:Ignorable");
+
+            this.CheckForXmlns("xamarin", element, ignorable, ref result);
+            this.CheckForXmlns("not_win", element, ignorable, ref result);
+            this.CheckForXmlns("android", element, ignorable, ref result);
+            this.CheckForXmlns("ios", element, ignorable, ref result);
+            this.CheckForXmlns("wasm", element, ignorable, ref result);
+            this.CheckForXmlns("macos", element, ignorable, ref result);
+
+            return result;
+        }
+
+        private void CheckForXmlns(string alias, RapidXamlElement element, RapidXamlAttribute ignorable, ref AnalysisActions actions)
+        {
+            var ns = element.Attributes.FirstOrDefault(a => a.ToString() == $"xmlns:{alias}=\"http:/uno.ui/{alias}\"");
+
+            if (ns != null && !ignorable.StringValue.Contains(alias))
+            {
+                actions.RemoveAttribute(
+                    RapidXamlErrorType.Warning,
+                    "RXT700",
+                    "xmlns '{0}' should be marked as ignorable.".WithParams(alias),
+                    "Mark {0} as ignorable".WithParams(alias),
+                    ignorable)
+                    .AndAddAttribute("mc:Ignorable", $"{ignorable.StringValue} {alias}");
+            }
+        }
+    }
+}

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocument.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocument.cs
@@ -167,6 +167,7 @@ namespace RapidXamlToolkit.XamlAnalysis
                 customProcessors.Add(new CustomAnalysis.Issue364ExampleAnalyzer2());
 #endif
                 customProcessors.Add(new CustomAnalysis.TwoPaneViewAnalyzer());
+                customProcessors.Add(new CustomAnalysis.UnoIgnorablesAnalyzer());
                 customProcessors.Add(new CustomAnalysis.LabelAnalyzer());
                 customProcessors.Add(new CustomAnalysis.XfImageAnalyzer());
                 customProcessors.Add(new CustomAnalysis.ImageButtonAnalyzer());

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="XamlAnalysis\CustomAnalyzers\FakeExtraAnalysisDetails.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\FooAnalysisTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\TwoPaneViewAnalyzerTests.cs" />
+    <Compile Include="XamlAnalysis\CustomAnalyzers\UnoIgnorableAnalyzerTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\EntryCellAnalyzerTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\XfImageAnalyzerTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\ImageButtonAnalyzerTests.cs" />

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/CustomAnalyzers/UnoIgnorableAnalyzerTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/CustomAnalyzers/UnoIgnorableAnalyzerTests.cs
@@ -1,0 +1,434 @@
+﻿// Copyright (c) Matt Lacey Ltd. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXaml;
+using RapidXaml.TestHelpers;
+using RapidXamlToolkit.XamlAnalysis.CustomAnalysis;
+
+namespace RapidXamlToolkit.Tests.XamlAnalysis.CustomAnalyzers
+{
+    [TestClass]
+    public class UnoIgnorableAnalyzerTests
+    {
+        [TestMethod]
+        public void CreateTag_ForXamarin_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:xamarin=""http:/uno.ui/xamarin""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForXamarin_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:xamarin=""http:/uno.ui/xamarin""
+    mc:Ignorable=""d xamarin"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForNotWin_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:not_win=""http:/uno.ui/not_win""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForNotWin_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:not_win=""http:/uno.ui/not_win""
+    mc:Ignorable=""d not_win"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForAndroid_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:android=""http:/uno.ui/android""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForAndroid_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:android=""http:/uno.ui/android""
+    mc:Ignorable=""d android"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForIos_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:ios=""http:/uno.ui/ios""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForIos_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:ios=""http:/uno.ui/ios""
+    mc:Ignorable=""d ios"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForWasm_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:wasm=""http:/uno.ui/wasm""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForWasm_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:wasm=""http:/uno.ui/wasm""
+    mc:Ignorable=""d wasm"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForForMacos_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:macos=""http:/uno.ui/macos""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(1, actual.Actions.Count);
+            Assert.AreEqual(ActionType.RemoveAttribute, actual.Actions[0].Action);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForForMacos_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:macos=""http:/uno.ui/macos""
+    mc:Ignorable=""d macos"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void CreateTag_ForAll_WhenNotInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:xamarin=""http:/uno.ui/xamarin""
+    xmlns:not_win=""http:/uno.ui/not_win""
+    xmlns:android=""http:/uno.ui/android""
+    xmlns:ios=""http:/uno.ui/ios""
+    xmlns:wasm=""http:/uno.ui/wasm""
+    xmlns:macos=""http:/uno.ui/macos""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(6, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void DontCreateTag_ForAll_WhenInIgnorableList()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    xmlns:xamarin=""http:/uno.ui/xamarin""
+    xmlns:not_win=""http:/uno.ui/not_win""
+    xmlns:android=""http:/uno.ui/android""
+    xmlns:ios=""http:/uno.ui/ios""
+    xmlns:wasm=""http:/uno.ui/wasm""
+    xmlns:macos=""http:/uno.ui/macos""
+    mc:Ignorable=""d xamarin not_win android ios wasm macos"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+
+        [TestMethod]
+        public void DoNothingWhenNoRelevantXmlnsUsed()
+        {
+            var xaml = @"<Page
+    x:Class=""App193.MainPage""
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:local=""using:App193""
+    xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+    xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+    mc:Ignorable=""d"">
+
+    <Grid Background=""{ThemeResource ApplicationPageBackgroundThemeBrush}"">
+		<TextBlock Text=""Hello, world!"" Margin=""20"" FontSize=""30"" />
+    </Grid>
+</Page>";
+
+            var rxElement = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var sut = new UnoIgnorablesAnalyzer();
+
+            var actual = sut.Analyze(rxElement, FakeExtraAnalysisDetails.Create(ProjectFramework.Uwp));
+
+            Assert.AreEqual(0, actual.Actions.Count);
+        }
+    }
+}

--- a/docs/warnings/RXT700.md
+++ b/docs/warnings/RXT700.md
@@ -1,0 +1,23 @@
+# RXT700
+
+Platform-specific Uno xmlns should be Ignorable.
+
+Applies to **UWP** only!
+
+## Description
+
+A platform-specific UNO XML namespace alias has been specified but not listed as ignorable when it should be.
+
+## Why this is suggested
+
+If the xmlns is not marked as ignorable the code may not compile or run as expected.
+
+## How to address the issue
+
+Press `Crtl + .` and use the suggested action 'Mark XXXXX as ignorable.'
+
+## Notes
+
+See also
+
+- [Platform-specific XAML markup in Uno](https://platform.uno/docs/articles/platform-specific-xaml.html)

--- a/docs/warnings/_template.md
+++ b/docs/warnings/_template.md
@@ -1,5 +1,7 @@
 # RXT???
 
+.
+
 ## Description
 
 .
@@ -15,3 +17,7 @@
 ## Notes
 
 .
+
+See also
+
+- [](https://)

--- a/docs/warnings/readme.md
+++ b/docs/warnings/readme.md
@@ -19,4 +19,5 @@ The following may be shown in the Error List.
 | [RXT402](./RXT402.md) | Use `MediaPlayerElement` in place of `MediaElement`. |
 | [RXT451](./RXT451.md) | `x:Uid` should begin with an upper case character. |
 | [RXT452](./RXT452.md) | `Name` should begin with an upper case character. |
+| [RXT700](./RXT700.md) | Platform-specific Uno xmlns should be Ignorable. |
 | [RXT999](./RXT999.md) | Unknown error - Something went wrong when parsing XAML document. |


### PR DESCRIPTION
This PR relates to Issue #328

**Description**  
Adds checks that xmlns that should be ignored are being.

**Confirm**
- [x] Everything builds in 'Release` mode
- [x] Docs updated
- [x] Release notes updated



