### PR TITLE
Pull file name from CF_VSSTGPROJECTITEMS

### DIFF
--- a/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandler.cs
+++ b/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandler.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
+
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
 using Microsoft.VisualStudio.Text.Operations;
+
+using Newtonsoft.Json;
+
 using RapidXamlToolkit.Commands;
 using RapidXamlToolkit.Logging;
 using RapidXamlToolkit.Resources;
@@ -23,15 +32,17 @@ namespace RapidXamlToolkit.DragDrop
         private readonly IFileSystemAbstraction fileSystem;
         private readonly IVisualStudioAbstraction vs;
         private readonly ProjectType projectType;
+        private readonly IVsSolution solution;
         private string draggedFilename;
 
-        public RapidXamlDropHandler(ILogger logger, IWpfTextView view, ITextBufferUndoManager undoManager, IVisualStudioAbstraction vs, ProjectType projectType, IFileSystemAbstraction fileSystem = null)
+        public RapidXamlDropHandler(ILogger logger, IWpfTextView view, ITextBufferUndoManager undoManager, IVisualStudioAbstraction vs, ProjectType projectType, IVsSolution solution, IFileSystemAbstraction fileSystem = null)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.view = view;
             this.undoManager = undoManager;
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.projectType = projectType;
+            this.solution = solution;
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
         }
 
@@ -92,17 +103,48 @@ namespace RapidXamlToolkit.DragDrop
             return File.Exists(fileName) && (fileName.EndsWith(".cs") || fileName.EndsWith(".vb"));
         }
 
-        private static string GetFilename(DragDropInfo info)
+        private string GetFilename(DragDropInfo info)
         {
-            DataObject data = new DataObject(info.Data);
-
-            // The drag and drop operation came from the VS solution explorer
-            if (info.Data.GetDataPresent("CF_VSSTGPROJECTITEMS"))
+            MemoryStream stream = info.Data.GetData("CF_VSSTGPROJECTITEMS") as MemoryStream;
+            if (stream != null)
             {
-                return data.GetText(); // This is the file path
+                string reference = EnumerateDroppedFiles(stream).FirstOrDefault();
+                if (ErrorHandler.Succeeded(this.solution.GetItemOfProjref(reference, out IVsHierarchy hierarchy, out uint itemId, out _, new VSUPDATEPROJREFREASON[1])))
+                {
+                    if (hierarchy is IVsProject project && ErrorHandler.Succeeded(project.GetMkDocument(itemId, out string fileName)))
+                    {
+                        return fileName;
+                    }
+                }
             }
 
             return null;
         }
+
+        private static IEnumerable<string> EnumerateDroppedFiles(MemoryStream stream)
+        {
+            const uint MAX_PATH = 260; // windef.h
+            char[] buffer = new char[MAX_PATH];
+
+            var handle = GCHandle.Alloc(stream.ToArray(), GCHandleType.Pinned);
+
+            try
+            {
+                uint length = DragQueryFile(handle.AddrOfPinnedObject(), 0xFFFFFFFF, null, 0);
+
+                for (uint i = 0; i < length; i++)
+                {
+                    uint charCount = DragQueryFile(handle.AddrOfPinnedObject(), i, buffer, (uint)buffer.Length);
+                    yield return new string(buffer, 0, (int)charCount);
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        [DllImport("shell32.dll", EntryPoint = "DragQueryFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+        private static extern uint DragQueryFile(IntPtr hDrop, uint iFile, char[] lpszFile, uint cch);
     }
 }

--- a/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandlerProvider.cs
+++ b/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandlerProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
@@ -25,6 +26,7 @@ namespace RapidXamlToolkit.DragDrop
     internal class RapidXamlDropHandlerProvider : IDropHandlerProvider
     {
         private static DTE dte;
+        private static IVsSolution solution;
 
         private static AsyncPackage Package { get; set; }
 
@@ -42,6 +44,7 @@ namespace RapidXamlToolkit.DragDrop
             Package = package;
 
             dte = await package.GetServiceAsync<DTE, DTE>();
+            solution = await package.GetServiceAsync<SVsSolution, IVsSolution>();
         }
 
         public IDropHandler GetAssociatedDropHandler(IWpfTextView view)
@@ -62,7 +65,7 @@ namespace RapidXamlToolkit.DragDrop
                     Logger?.RecordInfo(StringRes.Info_DetectedProjectType.WithParams(projType.GetDescription()));
                 }
 
-                return view.Properties.GetOrCreateSingletonProperty(() => new RapidXamlDropHandler(Logger, view, undoManager, vsa, projType));
+                return view.Properties.GetOrCreateSingletonProperty(() => new RapidXamlDropHandler(Logger, view, undoManager, vsa, projType, solution));
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
This works around the breaking change called out in https://developercommunity.visualstudio.com/content/problem/1175467/unable-to-get-name-of-file-dragged-from-solution-e.html.

I'll submit this as a draft, but feel free to grab this code and finish this to off to make it adhere to your standards/tests, etc. I did a quick test and this seems to work well across the C# project systems. You might want to also consider handling "FileDrop".