### PR TITLE
Update doc-link-checks.yml

### DIFF
--- a/.github/workflows/doc-link-checks.yml
+++ b/.github/workflows/doc-link-checks.yml
@@ -1,15 +1,14 @@
 name: 404 links
 
-# currently disabled based on https://github.com/restqa/404-links/issues/4
 
-#on: [push]
-#
-#jobs:
-#  check-links:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: 'restqa-404-links'
-#      uses: restqa/404-links@1.0.0
-#      with:
-#        path: 'docs'
+on: [push]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'restqa-404-links'
+      uses: restqa/404-links@v1.0.1
+      with:
+        path: 'docs'


### PR DESCRIPTION
Bump version of the 404-links checker in order to handle the empty link "(https://)" from the document : https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/warnings/_template.md

This PR relates to Issue #404

**Description**  
Due to an invalid link on the page https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/warnings/_template.md
The linter was able to handle that case.
So in fact this pull request is not update the code of this repo its just re-enabling the doc linter into the github action.

Result of the fix running here :  https://github.com/olivierodo/Rapid-XAML-Toolkit/runs/1092312772?check_suite_focus=true

### (not applicable)

**Confirm** 
- [ ] Everything builds in 'Release` mode
- [ ] Docs updated
- [ ] Release notes updated
- [ ] All tests in RapidXamlToolkit.Tests passed
- [ ] If changes analysis or generation - all tests in RapidXamlToolkit.Tests.Manual passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->

Resolve #404 

