### PR TITLE
Pull file name from CF_VSSTGPROJECTITEMS

### DIFF
--- a/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandler.cs
+++ b/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandler.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Windows;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
 using Microsoft.VisualStudio.Text.Operations;
@@ -23,15 +27,17 @@ namespace RapidXamlToolkit.DragDrop
         private readonly IFileSystemAbstraction fileSystem;
         private readonly IVisualStudioAbstraction vs;
         private readonly ProjectType projectType;
+        private readonly IVsSolution solution;
         private string draggedFilename;
 
-        public RapidXamlDropHandler(ILogger logger, IWpfTextView view, ITextBufferUndoManager undoManager, IVisualStudioAbstraction vs, ProjectType projectType, IFileSystemAbstraction fileSystem = null)
+        public RapidXamlDropHandler(ILogger logger, IWpfTextView view, ITextBufferUndoManager undoManager, IVisualStudioAbstraction vs, ProjectType projectType, IVsSolution solution, IFileSystemAbstraction fileSystem = null)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.view = view;
             this.undoManager = undoManager;
             this.vs = vs ?? throw new ArgumentNullException(nameof(vs));
             this.projectType = projectType;
+            this.solution = solution;
             this.fileSystem = fileSystem ?? new WindowsFileSystem();
         }
 
@@ -85,21 +91,65 @@ namespace RapidXamlToolkit.DragDrop
 
         public bool IsDropEnabled(DragDropInfo dragDropInfo)
         {
-            var fileName = GetFilename(dragDropInfo);
+            var fileName = this.GetFilename(dragDropInfo);
 
             this.draggedFilename = fileName;
+
+            System.Diagnostics.Debug.WriteLine($"fileName = {fileName}");
 
             return File.Exists(fileName) && (fileName.EndsWith(".cs") || fileName.EndsWith(".vb"));
         }
 
-        private static string GetFilename(DragDropInfo info)
+        private static IEnumerable<string> EnumerateDroppedFiles(MemoryStream stream)
         {
-            DataObject data = new DataObject(info.Data);
+            const uint MAX_PATH = 260; // windef.h
+            char[] buffer = new char[MAX_PATH];
 
-            // The drag and drop operation came from the VS solution explorer
-            if (info.Data.GetDataPresent("CF_VSSTGPROJECTITEMS"))
+            var handle = GCHandle.Alloc(stream.ToArray(), GCHandleType.Pinned);
+
+            try
             {
-                return data.GetText(); // This is the file path
+                uint length = DragQueryFile(handle.AddrOfPinnedObject(), 0xFFFFFFFF, null, 0);
+
+                System.Diagnostics.Debug.WriteLine($"length = {length}");
+
+                for (uint i = 0; i < length; i++)
+                {
+                    uint charCount = DragQueryFile(handle.AddrOfPinnedObject(), i, buffer, (uint)buffer.Length);
+                    yield return new string(buffer, 0, (int)charCount);
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        [DllImport("shell32.dll", EntryPoint = "DragQueryFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+        private static extern uint DragQueryFile(IntPtr hDrop, uint iFile, char[] lpszFile, uint cch);
+
+        private string GetFilename(DragDropInfo info)
+        {
+            if (info.Data.GetData("CF_VSSTGPROJECTITEMS") is MemoryStream stream)
+            {
+                var tryCount = 0;
+                string reference = null;
+
+                // Calls to DragQueryFile (within EnumerateDroppedFiles) aren't returning consistently.
+                // Retrying a few times (although far from ideal) seems to work ok.
+                while (tryCount < 5 && string.IsNullOrWhiteSpace(reference))
+                {
+                    reference = EnumerateDroppedFiles(stream).FirstOrDefault();
+                    tryCount += 1;
+                }
+
+                if (ErrorHandler.Succeeded(this.solution.GetItemOfProjref(reference, out IVsHierarchy hierarchy, out uint itemId, out _, new VSUPDATEPROJREFREASON[1])))
+                {
+                    if (hierarchy is IVsProject project && ErrorHandler.Succeeded(project.GetMkDocument(itemId, out string fileName)))
+                    {
+                        return fileName;
+                    }
+                }
             }
 
             return null;

--- a/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandlerProvider.cs
+++ b/VSIX/RapidXaml.Generation/DragDrop/RapidXamlDropHandlerProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
@@ -25,6 +26,7 @@ namespace RapidXamlToolkit.DragDrop
     internal class RapidXamlDropHandlerProvider : IDropHandlerProvider
     {
         private static DTE dte;
+        private static IVsSolution solution;
 
         private static AsyncPackage Package { get; set; }
 
@@ -42,6 +44,7 @@ namespace RapidXamlToolkit.DragDrop
             Package = package;
 
             dte = await package.GetServiceAsync<DTE, DTE>();
+            solution = await package.GetServiceAsync<SVsSolution, IVsSolution>();
         }
 
         public IDropHandler GetAssociatedDropHandler(IWpfTextView view)
@@ -62,7 +65,7 @@ namespace RapidXamlToolkit.DragDrop
                     Logger?.RecordInfo(StringRes.Info_DetectedProjectType.WithParams(projType.GetDescription()));
                 }
 
-                return view.Properties.GetOrCreateSingletonProperty(() => new RapidXamlDropHandler(Logger, view, undoManager, vsa, projType));
+                return view.Properties.GetOrCreateSingletonProperty(() => new RapidXamlDropHandler(Logger, view, undoManager, vsa, projType, solution));
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
Based on #403 but with the following differences.

- Adds retry logic for calling `DragQueryFile` (from shell32.dll)
- Meets formatting enforcement rules

**Confirm**
- [x] Everything builds in 'Release` mode
-  ~Docs updated~
-  ~Release notes updated~
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in RapidXamlToolkit.Tests.Manual passed





