### PR TITLE
Support concise RowDefinitions and ColumnDefinitions in Xamarin.FOrms projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rapid XAML Toolkit - ChangeLog
 
+## 0.11.4
+
+- Support succinct Row and Column Definitions in RapidXaml.Analysis.
+
 ## 0.11.3
 
 - Avoid duplicate output from BuildAnalysis.

--- a/Templates/CustomAnalysisItemTemplate/CustomAnalysisItemTemplate.vstemplate
+++ b/Templates/CustomAnalysisItemTemplate/CustomAnalysisItemTemplate.vstemplate
@@ -20,7 +20,7 @@
     </WizardExtension>
     <WizardData>
         <packages>
-            <package id="RapidXaml.CustomAnalysis" version="0.11.3" />
+            <package id="RapidXaml.CustomAnalysis" version="0.11.4" />
         </packages>
     </WizardData>
 </VSTemplate>

--- a/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.csproj
+++ b/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.11.3" />
+        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.11.4" />
     </ItemGroup>
 
 </Project>

--- a/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.nuspec
+++ b/Templates/CustomAnalysisProjectTemplate/Analyzer/CustomAnalyzerProject.nuspec
@@ -13,7 +13,7 @@
         <tags>RapidXaml, XamlAnalyzer</tags>
         <dependencies>
             <group targetFramework="netstandard2.0">
-                <dependency id="RapidXaml.CustomAnalysis" version="0.11.3" exclude="Build,Analyzers" />
+                <dependency id="RapidXaml.CustomAnalysis" version="0.11.4" exclude="Build,Analyzers" />
             </group>
         </dependencies>
     </metadata>

--- a/Templates/CustomAnalysisProjectTemplate/AnalyzerTests/CustomAnalyzerProjectTests.csproj
+++ b/Templates/CustomAnalysisProjectTemplate/AnalyzerTests/CustomAnalyzerProjectTests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.11.3" />
+        <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.11.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Templates/RapidXaml.Templates/Properties/AssemblyInfo.cs
+++ b/Templates/RapidXaml.Templates/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/Templates/RapidXaml.Templates/RapidXamlTemplatesPackage.cs
+++ b/Templates/RapidXaml.Templates/RapidXamlTemplatesPackage.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace RapidXaml.Templates
 {
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(RapidXamlTemplatesPackage.PackageGuidString)]
     public sealed class RapidXamlTemplatesPackage : AsyncPackage

--- a/Templates/RapidXaml.Templates/source.extension.vsixmanifest
+++ b/Templates/RapidXaml.Templates/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Templates</DisplayName>
-        <Description xml:space="preserve">Project and item templates to help with XAML development.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/custom-analysis.md</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlTemplatesLogo.png</Icon>
-        <Tags>XAML</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CustomAnalysisItemTemplate" d:TargetPath="|CustomAnalysisItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CustomAnalysisProjectTemplate.zip" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Templates</DisplayName>
+    <Description xml:space="preserve">Project and item templates to help with XAML development.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/custom-analysis.md</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlTemplatesLogo.png</Icon>
+    <Tags>XAML</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CustomAnalysisItemTemplate" d:TargetPath="|CustomAnalysisItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CustomAnalysisProjectTemplate.zip" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]
 
 ////[assembly: InternalsVisibleTo(
 ////    "RapidXamlToolkit.Tests, PublicKey=" +

--- a/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
+++ b/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
@@ -21,7 +21,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(RapidXamlAnalysisPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(AnalysisOptionsGrid), "Rapid XAML", "Analysis", 106, 107, true)]

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/GridProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/GridProcessor.cs
@@ -35,10 +35,32 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                 hasRowDef = firstNestedGrid <= 0 || rowDefPos < firstNestedGrid;
             }
 
+            string rowDefsString = null;
+
+            if (rowDefPos < 0 && this.ProjectType.Matches(ProjectType.XamarinForms))
+            {
+                // See if using new inline format
+                if (this.TryGetAttribute(xamlElement, Attributes.RowDefinitions, AttributeType.Inline, out _, out _, out _, out rowDefsString))
+                {
+                    hasRowDef = true;
+                }
+            }
+
             var hasColDef = false;
             if (colDefPos > 0)
             {
                 hasColDef = firstNestedGrid <= 0 || colDefPos < firstNestedGrid;
+            }
+
+            string colDefsString = null;
+
+            if (colDefPos < 0 && this.ProjectType.Matches(ProjectType.XamarinForms))
+            {
+                // See if using new inline format
+                if (this.TryGetAttribute(xamlElement, Attributes.ColumnDefinitions, AttributeType.Inline, out _, out _, out _, out colDefsString))
+                {
+                    hasColDef = true;
+                }
             }
 
             var leftPad = linePadding.Contains("\t") ? linePadding + "\t" : linePadding + "    ";
@@ -126,6 +148,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                 rowDefIndex = xamlElement.IndexOf(rowDefStart, endPos, StringComparison.Ordinal);
             }
 
+            if (rowDefsCount == 0 && !string.IsNullOrEmpty(rowDefsString))
+            {
+                rowDefsCount = rowDefsString.Split(new[] { ',' }, StringSplitOptions.None).Length;
+            }
+
             foreach (var tag in toAdd)
             {
                 tag.RowCount = rowDefsCount;
@@ -143,6 +170,11 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
                 colDefsCount += 1;
 
                 colDefIndex = xamlElement.IndexOf(colDef, colDefIndex + 1, StringComparison.Ordinal);
+            }
+
+            if (colDefsCount == 0 && !string.IsNullOrEmpty(colDefsString))
+            {
+                colDefsCount = colDefsString.Split(new[] { ',' }, StringSplitOptions.None).Length;
             }
 
             const string rowDefUse = "Grid.Row=\"";

--- a/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Analysis</DisplayName>
-        <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlAnalysisLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, Roslyn, Analysis</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Analysis</DisplayName>
+    <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlAnalysisLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, Roslyn, Analysis</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/Attributes.cs
+++ b/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/Attributes.cs
@@ -17,6 +17,8 @@ namespace RapidXamlToolkit.XamlAnalysis
 
         public static string CheckedEvent => "Checked";
 
+        public static string ColumnDefinitions => "ColumnDefinitions";
+
         public static string Content => "Content";
 
         public static string Description => "Description";
@@ -42,6 +44,8 @@ namespace RapidXamlToolkit.XamlAnalysis
         public static string Placeholder => "Placeholder";
 
         public static string PlaceholderText => "PlaceholderText";
+
+        public static string RowDefinitions => "RowDefinitions";
 
         public static string SelectedItem => "SelectedItem";
 

--- a/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
+++ b/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;ANALYSISEXE</DefineConstants>

--- a/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.csproj
+++ b/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
   </PropertyGroup>
   <!-- Pack settings -->
   <PropertyGroup>

--- a/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.nuspec
+++ b/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>RapidXaml.AutoFix</id>
-    <version>0.11.3</version>
+    <version>0.11.4</version>
     <authors>Matt Lacey</authors>
     <owners>MRLacey</owners>
     <license type="expression">MIT</license>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
   </PropertyGroup>
   <!-- Pack settings -->
   <PropertyGroup>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>RapidXaml.BuildAnalysis</id>
-    <version>0.11.3</version>
+    <version>0.11.4</version>
     <authors>Matt Lacey</authors>
     <owners>MRLacey</owners>
     <copyright>Copyright © 2020 Matt Lacey Ltd.</copyright>

--- a/VSIX/RapidXaml.Common/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Common/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXaml.Common/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Common/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Common Functionality</DisplayName>
-        <Description xml:space="preserve">Common infrastructure used by other extensions that are part of the Rapid XAML Toolkit.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlCommonLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Common Functionality</DisplayName>
+    <Description xml:space="preserve">Common infrastructure used by other extensions that are part of the Rapid XAML Toolkit.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlCommonLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.CustomAnalysis/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.csproj
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>RapidXaml.CustomAnalysis</id>
-    <version>0.11.3</version>
+    <version>0.11.4</version>
     <authors>Matt Lacey</authors>
     <owners>MRLacey</owners>
     <license type="expression">MIT</license>

--- a/VSIX/RapidXaml.EditorExtras/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.EditorExtras/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXaml.EditorExtras/RapidXamlEditorExtrasPackage.cs
+++ b/VSIX/RapidXaml.EditorExtras/RapidXamlEditorExtrasPackage.cs
@@ -17,7 +17,7 @@ namespace RapidXaml.EditorExtras
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [Guid(RapidXamlEditorExtrasPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(EditorExtrasOptionsGrid), "Rapid XAML", "Editor", 106, 107, true)]
     [ProvideProfile(typeof(EditorExtrasOptionsGrid), "Rapid XAML", "Editor", 106, 107, true)]

--- a/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Editor Extras</DisplayName>
-        <Description xml:space="preserve">Tools to accelerate XAML app development by providing additional features to the Visual Studio editor.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlEditorExtrasLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, Roslyn, Analysis</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Dependencies>
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Editor Extras</DisplayName>
+    <Description xml:space="preserve">Tools to accelerate XAML app development by providing additional features to the Visual Studio editor.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlEditorExtrasLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, Roslyn, Analysis</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Dependencies>
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Generation/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Generation/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXaml.Generation/RapidXamlGenerationPackage.cs
+++ b/VSIX/RapidXaml.Generation/RapidXamlGenerationPackage.cs
@@ -21,7 +21,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(RapidXamlGenerationPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(SettingsConfigPage), "Rapid XAML", "Generation Profiles", 106, 107, true)]

--- a/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Generation</DisplayName>
-        <Description xml:space="preserve">Tools to accelerate XAML app development by generating XAML.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlGenerationLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, generation</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
-    </Installation>
-    <Dependencies>
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Generation</DisplayName>
+    <Description xml:space="preserve">Tools to accelerate XAML app development by generating XAML.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlGenerationLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, Forms, MVVM, generation</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
+  </Installation>
+  <Dependencies>
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.RoslynAnalyzers/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.RoslynAnalyzers/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXaml.RoslynAnalyzers/RapidXamlRoslynAnalyzersPackage.cs
+++ b/VSIX/RapidXaml.RoslynAnalyzers/RapidXamlRoslynAnalyzersPackage.cs
@@ -16,7 +16,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [Guid(RapidXamlRoslynAnalyzersPackage.PackageGuidString)]
     public sealed class RapidXamlRoslynAnalyzersPackage : AsyncPackage
     {

--- a/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML RoslynAnalyzers</DisplayName>
-        <Description xml:space="preserve">Roslyn analyzers to help with XAML app development.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://rapidxaml.dev/roslyn-analyzers</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlRoslynAnalyzersLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML RoslynAnalyzers</DisplayName>
+    <Description xml:space="preserve">Roslyn analyzers to help with XAML app development.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://rapidxaml.dev/roslyn-analyzers</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlRoslynAnalyzersLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Shared/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Shared/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/Processors/GridProcessorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/Processors/GridProcessorTests.cs
@@ -153,5 +153,57 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis.Processors
 
             Assert.AreEqual(1, outputTags.OfType<ColumnSpanOverflowTag>().Count());
         }
+
+        [TestMethod]
+        public void DetectConcise_RowDefinitions()
+        {
+            var xaml = @"<Grid RowDefinitions=""*,*"">
+    <Label Grid.Row=""1"" />
+</Grid>";
+
+            var outputTags = this.GetTags<GridProcessor>(xaml, ProjectType.XamarinForms);
+
+            Assert.AreEqual(0, outputTags.OfType<AddRowDefinitionsTag>().Count());
+            Assert.AreEqual(0, outputTags.OfType<MissingRowDefinitionTag>().Count());
+        }
+
+        [TestMethod]
+        public void DetectConcise_ColumnDefinitions()
+        {
+            var xaml = @"<Grid ColumnDefinitions=""*,*"">
+    <Label Grid.Column=""1"" />
+</Grid>";
+
+            var outputTags = this.GetTags<GridProcessor>(xaml, ProjectType.XamarinForms);
+
+            Assert.AreEqual(0, outputTags.OfType<AddColumnDefinitionsTag>().Count());
+            Assert.AreEqual(0, outputTags.OfType<MissingColumnDefinitionTag>().Count());
+        }
+
+        [TestMethod]
+        public void DetectOutsideConcise_RowDefinitions()
+        {
+            var xaml = @"<Grid RowDefinitions=""*,*"">
+    <Label Grid.Row=""2"" />
+</Grid>";
+
+            var outputTags = this.GetTags<GridProcessor>(xaml, ProjectType.XamarinForms);
+
+            Assert.AreEqual(0, outputTags.OfType<AddRowDefinitionsTag>().Count());
+            Assert.AreEqual(1, outputTags.OfType<MissingRowDefinitionTag>().Count());
+        }
+
+        [TestMethod]
+        public void DetectOutsideConcise_ColumnDefinitions()
+        {
+            var xaml = @"<Grid ColumnDefinitions=""*,*"">
+    <Label Grid.Column=""2"" />
+</Grid>";
+
+            var outputTags = this.GetTags<GridProcessor>(xaml, ProjectType.XamarinForms);
+
+            Assert.AreEqual(0, outputTags.OfType<AddColumnDefinitionsTag>().Count());
+            Assert.AreEqual(1, outputTags.OfType<MissingColumnDefinitionTag>().Count());
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXamlToolkit/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.3.0")]
-[assembly: AssemblyFileVersion("0.11.3.0")]
+[assembly: AssemblyVersion("0.11.4.0")]
+[assembly: AssemblyFileVersion("0.11.4.0")]

--- a/VSIX/RapidXamlToolkit/RapidXamlPackage.cs
+++ b/VSIX/RapidXamlToolkit/RapidXamlPackage.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Shell;
 namespace RapidXamlToolkit
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.11.3")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.11.4")] // Info on this package for Help/About
     [Guid("ed7fe961-2d10-4598-8040-7423b66b6540")]
     public sealed class RapidXamlPackage : AsyncPackage
     {

--- a/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.11.3" Language="en-US" Publisher="Matt Lacey" />
-        <DisplayName>Rapid XAML Toolkit</DisplayName>
-        <Description xml:space="preserve">Tools to accelerate XAML app development.</Description>
-        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-        <License>LICENSE.txt</License>
-        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\RapidXamlToolkitLogo.png</Icon>
-        <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.11.4" Language="en-US" Publisher="Matt Lacey" />
+    <DisplayName>Rapid XAML Toolkit</DisplayName>
+    <Description xml:space="preserve">Tools to accelerate XAML app development.</Description>
+    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+    <License>LICENSE.txt</License>
+    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\RapidXamlToolkitLogo.png</Icon>
+    <Tags>XAML, UWP, WPF, Xamarin.Forms, Uno, MVVM</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
This PR relates to Issue #430

**Description**  
<!-- Please provide a brief description of what's being committed. -->
Don't warn about missing `RowDefinitions` or `ColumnDefinitions` when using the new, succinct/concise format available in Xamarin.Forms


**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated ***n/a**
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in RapidXamlToolkit.Tests.Manual passed


