### PR TITLE
Correctly update RXE & RXA span locations for cached elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rapid XAML Toolkit - ChangeLog
 
+## Upcoming
+
+- Fix bug where the location of items to underline was not calculated correctly.
+
 ## 0.11.4
 
 - Support succinct Row and Column Definitions in RapidXaml.Analysis.

--- a/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/RapidXamlElementExtractor.cs
+++ b/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/RapidXamlElementExtractor.cs
@@ -115,7 +115,7 @@ namespace RapidXamlToolkit.XamlAnalysis
                                     childElement.Width);
                             }
 
-                            var childAsString = xaml.TrimStart().Substring(childElement.Start, childElement.Width);
+                            var childAsString = xaml.TrimStart().Substring(childElement.SpanStart, childElement.Width);
 
                             if (content.TrimStart().StartsWith(childAsString.TrimStart()))
                             {

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXamlAttribute.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXamlAttribute.cs
@@ -74,6 +74,24 @@ namespace RapidXaml
         /// </summary>
         public RapidXamlSpan Location { get; internal set; } = new RapidXamlSpan();
 
+        public RapidXamlAttribute CloneWithAdjustedLocationStart(int startChange)
+        {
+            var result = new RapidXamlAttribute
+            {
+                Name = this.Name,
+                IsInline = this.IsInline,
+                StringValue = this.StringValue,
+                Location = this.Location.CloneWithAdjustedLocationStart(startChange),
+            };
+
+            for (int i = 0; i < this.Children.Count; i++)
+            {
+                result.Children.Add(this.Children[i].CloneWithAdjustedLocationStart(startChange));
+            }
+
+            return result;
+        }
+
         /// <inheritdoc/>
         public override string ToString()
         {

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXamlElement.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXamlElement.cs
@@ -279,15 +279,34 @@ namespace RapidXaml
 
         public RapidXamlElement WithUpdatedLocationStart(int newLocationStart)
         {
+            var change = newLocationStart - this.Location.Start;
+
+            var result = this.CloneWithAdjustedLocationStart(change);
+
+            result.Location = new RapidXamlSpan(newLocationStart, this.Location.Length);
+
+            return result;
+        }
+
+        public RapidXamlElement CloneWithAdjustedLocationStart(int startChange)
+        {
             var result = new RapidXamlElement
             {
-                Attributes = this.Attributes,
-                Children = this.Children,
                 Content = this.Content,
-                Location = new RapidXamlSpan(newLocationStart, this.Location.Length),
+                Location = this.Location.CloneWithAdjustedLocationStart(startChange),
                 Name = this.Name,
                 OriginalString = this.OriginalString,
             };
+
+            for (int i = 0; i < this.Attributes.Count; i++)
+            {
+                result.Attributes.Add(this.Attributes[i].CloneWithAdjustedLocationStart(startChange));
+            }
+
+            for (int i = 0; i < this.Children.Count; i++)
+            {
+                result.Children.Add(this.Children[i].CloneWithAdjustedLocationStart(startChange));
+            }
 
             return result;
         }

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXamlSpan.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXamlSpan.cs
@@ -19,6 +19,11 @@ namespace RapidXaml
 
         public int Length { get; set; } = -1;
 
+        public RapidXamlSpan CloneWithAdjustedLocationStart(int startChange)
+        {
+            return new RapidXamlSpan(this.Start + startChange, this.Length);
+        }
+
         public override string ToString()
         {
             return $"({this.Start}, {this.Length})";

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RapidXamlElementExtractorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RapidXamlElementExtractorTests.cs
@@ -1745,5 +1745,36 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
             Assert.AreEqual("<ColumnDefinition Width=\"Auto\" />", xaml.Substring(attr.Children[2].Location.Start, attr.Children[2].Location.Length));
             Assert.AreEqual("<ColumnDefinition Width=\"2*\" />", xaml.Substring(attr.Children[3].Location.Start, attr.Children[3].Location.Length));
         }
+
+        [TestMethod]
+        public void AllLocationsUpdatedWhenGetCachedValueWIthDifferentOffset()
+        {
+            var xaml = "<Person Moniker=\"Monica\">" +
+  Environment.NewLine + "    <Child ParentName=\"Monica\" OtherParentName=\"Derek\">" +
+  Environment.NewLine + "        <Child.Age>14</Child.Age>" +
+  Environment.NewLine + "        <Child.Name><string>Carla</string></Child.Name>" +
+  Environment.NewLine + "        <Child.Pet><Hamster /></Child.Pet>" +
+  Environment.NewLine + "        <GrandChild><GrandChild.Nom><Identifier Id=\"Bobby\" /><GrandChild.Nom></GrandChild>" +
+  Environment.NewLine + "    </Child>" +
+  Environment.NewLine + "    <Sibling Name=\"Mary\">" +
+  Environment.NewLine + "        <ParentMoniker Value=\"Monica\" />" +
+  Environment.NewLine + "    </Sibling>" +
+  Environment.NewLine + "</Person>";
+
+            var first = RapidXamlElementExtractor.GetElement(xaml, 0);
+
+            var second = RapidXamlElementExtractor.GetElement(xaml, 10);
+
+            Assert.AreNotEqual(first.Location.Start, second.Location.Start);
+            Assert.AreNotEqual(first.Attributes.First().Location.Start, second.Attributes.First().Location.Start);
+
+            Assert.AreNotEqual(first.Children.First().Location.Start, second.Children.First().Location.Start);
+            Assert.AreNotEqual(first.Children.First().Attributes.First().Location.Start, second.Children.First().Attributes.First().Location.Start);
+            Assert.AreNotEqual(first.Children.First().Attributes.Last().Location.Start, second.Children.Last().Attributes.First().Location.Start);
+
+            Assert.AreNotEqual(first.Children.First().Children.First().Location.Start, second.Children.First().Children.First().Location.Start);
+
+            Assert.AreNotEqual(first.Children.Last().Location.Start, second.Children.Last().Location.Start);
+        }
     }
 }


### PR DESCRIPTION
This PR relates to Issue #438 & #396

**Description**  
<!-- Please provide a brief description of what's being committed. -->
Ensure that span locations are correctly updated when working with cached RapidXamlElements
this addresses issues where squiggles are drawn incorrectly (or not at all when an error tries to put them outside of the available content).

**Confirm**
- [x] Everything builds in 'Release` mode
-  Docs updated
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed


