### PR TITLE
Add tests for files containing <lt; but unencoded '>'

### DIFF
--- a/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/XamlElementExtractor.cs
+++ b/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/XamlElementExtractor.cs
@@ -174,6 +174,7 @@ namespace RapidXamlToolkit.XamlAnalysis
                                 }
                             }
 
+                            // This might not be the case if the was an encoded opening but not an encoded closing angle bracket
                             if (!string.IsNullOrWhiteSpace(toProcess.ElementName))
                             {
                                 var elementBody = xaml.Substring(toProcess.StartPos, i - toProcess.StartPos + 1);
@@ -234,21 +235,6 @@ namespace RapidXamlToolkit.XamlAnalysis
                                 }
 
                                 elementsBeingTracked.Remove(toProcess);
-                            }
-                            else
-                            {
-                                // Account for unknown startPos until address ISSUE#400
-                                if (!inComment && currentElementStartPos >= 0)
-                                {
-                                    var elementBody = xaml.Substring(currentElementStartPos, i - currentElementStartPos + 1);
-
-                                    // Don't process closing blocks
-                                    if (!elementBody.StartsWith("</"))
-                                    {
-                                        // Do this in the else so don't always have to calculate the substring.
-                                        everyElementProcessor?.Process(fileName, currentElementStartPos, elementBody, lineIndent.ToString(), snapshot, tags, suppressions, xmlnsAliases);
-                                    }
-                                }
                             }
 
                             // Reset this so know what we should be tracking

--- a/VSIX/RapidXamlToolkit.Tests/Misc/AsyncRelayCommandPage.xaml
+++ b/VSIX/RapidXamlToolkit.Tests/Misc/AsyncRelayCommandPage.xaml
@@ -1,0 +1,90 @@
+﻿<Page
+    x:Class="MvvmSampleUwp.Views.AsyncRelayCommandPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:controls="using:MvvmSampleUwp.Controls"
+    xmlns:viewModels="using:MvvmSampleUwp.ViewModels"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
+    <Page.DataContext>
+        <viewModels:AsyncRelayCommandPageViewModel x:Name="ViewModel"/>
+    </Page.DataContext>
+    <interactivity:Interaction.Behaviors>
+        <core:EventTriggerBehavior EventName="Loaded">
+            <core:InvokeCommandAction Command="{x:Bind ViewModel.LoadDocsCommand}" CommandParameter="AsyncRelayCommand"/>
+        </core:EventTriggerBehavior>
+    </interactivity:Interaction.Behaviors>
+    <Page.Resources>
+        <converters:TaskResultConverter x:Key="TaskResultConverter"/>
+    </Page.Resources>
+
+    <ScrollViewer Padding="16" CanContentRenderOutsideBounds="True">
+        <StackPanel Spacing="16">
+            <toolkit:MarkdownTextBlock Text="{x:Bind ViewModel.GetParagraph('AsyncRelayCommand and AsyncRelayCommand&lt;T>'), Mode=OneWay}"/>
+            <toolkit:MarkdownTextBlock Text="{x:Bind ViewModel.GetParagraph('How they work'), Mode=OneWay}"/>
+            <toolkit:MarkdownTextBlock Text="{x:Bind ViewModel.GetParagraph('Working with asynchronous commands'), Mode=OneWay}"/>
+
+            <controls:InteractiveSample xml:space="preserve">
+                <controls:InteractiveSample.Content>
+                    <StackPanel Spacing="8" xml:space="default">
+                        <TextBlock>
+                            <Run Text="Task status:"/>
+                            <Run Text="{x:Bind ViewModel.DownloadTextCommand.ExecutionTask.Status, Mode=OneWay}"/>
+                            <LineBreak/>
+                            <Run Text="Result:"/>
+                            <Run Text="{x:Bind ViewModel.DownloadTextCommand.ExecutionTask, Converter={StaticResource TaskResultConverter}, Mode=OneWay}"/>
+                        </TextBlock>
+                        <Button
+                            Content="Click me!"
+                            Command="{x:Bind ViewModel.DownloadTextCommand}"/>
+                        <muxc:ProgressRing
+                            HorizontalAlignment="Left"
+                            IsActive="{x:Bind ViewModel.DownloadTextCommand.IsRunning, Mode=OneWay}"/>
+                    </StackPanel>
+                </controls:InteractiveSample.Content>
+                <controls:InteractiveSample.XamlCode>
+&lt;Page.Resources>
+    &lt;converters:TaskResultConverter x:Key="TaskResultConverter"/>
+&lt;/Page.Resources>
+&lt;StackPanel Spacing="8">
+    &lt;TextBlock>
+        &lt;Run Text="Task status:"/>
+        &lt;Run Text="{x:Bind ViewModel.DownloadTextCommand.ExecutionTask.Status, Mode=OneWay}"/>
+        &lt;LineBreak/>
+        &lt;Run Text="Result:"/>
+        &lt;Run Text="{x:Bind ViewModel.DownloadTextCommand.ExecutionTask, Converter={StaticResource TaskResultConverter}, Mode=OneWay}"/>
+    &lt;/TextBlock>
+    &lt;Button
+        Content="Click me!"
+        Command="{x:Bind ViewModel.DownloadTextCommand}"/>
+    &lt;muxc:ProgressRing
+        HorizontalAlignment="Left"
+        IsActive="{x:Bind ViewModel.DownloadTextCommand.IsRunning, Mode=OneWay}"/>
+&lt;/StackPanel>
+                </controls:InteractiveSample.XamlCode>
+                <controls:InteractiveSample.CSharpCode>
+public MyViewModel()
+{
+    DownloadTextCommand = new AsyncRelayCommand(DownloadTextAsync);
+}
+
+public IAsyncRelayCommand DownloadTextCommand { get; }
+
+private async Task&lt;string> DownloadTextAsync()
+{
+    await Task.Delay(3000); // Simulate a web request
+
+    return "Hello world!";
+}
+                </controls:InteractiveSample.CSharpCode>
+            </controls:InteractiveSample>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/VSIX/RapidXamlToolkit.Tests/Misc/MiscRealWorldTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Misc/MiscRealWorldTests.cs
@@ -96,6 +96,22 @@ namespace RapidXamlToolkit.Tests.Misc
         }
 
         [TestMethod]
+        public void Real_AsyncRelayCommandPage()
+        {
+            var result = new RapidXamlDocument();
+
+            var text = File.ReadAllText(".\\Misc\\AsyncRelayCommandPage.xaml");
+
+            var snapshot = new FakeTextSnapshot(text.Length);
+            var vsa = new TestVisualStudioAbstraction();
+            var logger = DefaultTestLogger.Create();
+
+            XamlElementExtractor.Parse("AsyncRelayCommandPage.xaml", snapshot, text, RapidXamlDocument.GetAllProcessors(ProjectType.Uwp, string.Empty, vsa, logger), result.Tags, null, RapidXamlDocument.GetEveryElementProcessor(ProjectType.Uwp, null, vsa), logger);
+
+            Assert.IsTrue(true, "Got here without error.");
+        }
+
+        [TestMethod]
         public void Real_ParseWithoutError_ComboBox()
         {
             this.ParseWithoutError(".\\Misc\\ComboBox.xaml", ProjectType.Wpf);

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\SearchBarAnalyzerTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\RadioButtonAnalyzerTests.cs" />
     <Compile Include="XamlAnalysis\CustomAnalyzers\XamarinForms\PickerAnalyzerTests.cs" />
+    <Compile Include="XamlAnalysis\CustomAnalyzers\XmlEncodingTests.cs" />
     <Compile Include="XamlAnalysis\FakeXamlElementProcessor.cs" />
     <Compile Include="XamlAnalysis\Processors\AppBarButtonProcessorTests.cs" />
     <Compile Include="XamlAnalysis\Processors\AppBarToggleButtonProcessorTests.cs" />
@@ -295,6 +296,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Misc\XmlSpace1.xaml">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Misc\AsyncRelayCommandPage.xaml">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/CustomAnalyzers/XmlEncodingTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/CustomAnalyzers/XmlEncodingTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Matt Lacey Ltd. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RapidXaml;
+using RapidXamlToolkit.XamlAnalysis;
+
+namespace RapidXamlToolkit.Tests.XamlAnalysis.CustomAnalyzers
+{
+    [TestClass]
+    public class XmlEncodingTests
+    {
+        [TestMethod]
+        public void AnalyzerGetsCorrectContent()
+        {
+            var xaml = @"
+<StackPanel>
+    <TextBlock>&lt;Page.Resources>NONE&lt;/Page.Resources></TextBlock>
+</StackPanel>";
+
+            var result = new RapidXamlDocument();
+
+            var snapshot = new FakeTextSnapshot(xaml.Length);
+            var logger = DefaultTestLogger.Create();
+            var vsa = new TestVisualStudioAbstraction();
+
+            var analyzer = new XmlEncodingTestAnalyzer();
+
+            var processors = RapidXamlDocument.WrapCustomProcessors(
+                new List<ICustomAnalyzer> { analyzer },
+                ProjectType.Unknown,
+                string.Empty,
+                logger,
+                vsa);
+
+            XamlElementExtractor.Parse("Generic.xaml", snapshot, xaml, processors.ToList(), result.Tags, null, null, logger);
+
+            Assert.AreEqual("&lt;Page.Resources>NONE&lt;/Page.Resources>", analyzer.Element.Content);
+        }
+
+        public class XmlEncodingTestAnalyzer : ICustomAnalyzer
+        {
+            public RapidXamlElement Element { get; set; }
+
+            public string TargetType() => "TextBlock";
+
+            public AnalysisActions Analyze(RapidXamlElement element, ExtraAnalysisDetails extraDetails)
+            {
+                this.Element = element;
+
+                return AnalysisActions.None;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR relates to Issue #400

**Description**  
Added test to ensure previous workaround was sufficient

**Confirm**
- [x] Everything builds in 'Release` mode
-  Docs updated
-  Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed



