### PR TITLE
Be able to create resource string for WPF apps

### DIFF
--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/TextBlockProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/TextBlockProcessor.cs
@@ -17,7 +17,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
         public override void Process(string fileName, int offset, string xamlElement, string linePadding, ITextSnapshot snapshot, TagList tags, List<TagSuppression> suppressions = null, Dictionary<string, string> xlmns = null)
         {
-            if (!this.ProjectType.Matches(ProjectType.Uwp))
+            if (this.ProjectType.Matches(ProjectType.XamarinForms))
             {
                 return;
             }

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/TextBlockProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/TextBlockProcessor.cs
@@ -17,7 +17,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
         public override void Process(string fileName, int offset, string xamlElement, string linePadding, ITextSnapshot snapshot, TagList tags, List<TagSuppression> suppressions = null, Dictionary<string, string> xlmns = null)
         {
-            if (this.ProjectType.Matches(ProjectType.XamarinForms))
+            if (this.ProjectType == ProjectType.XamarinForms)
             {
                 return;
             }

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocument.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/RapidXamlDocument.cs
@@ -257,7 +257,6 @@ namespace RapidXamlToolkit.XamlAnalysis
             return new List<ICustomAnalyzer>();
         }
 
-        // TODO: ISSUE#331 cache this response so don't need to look up again if files haven't changed.
         public static List<ICustomAnalyzer> GetCustomAnalyzers(string folderToSearch)
         {
             var result = new List<ICustomAnalyzer>();

--- a/VSIX/RapidXaml.Shared/VisualStudioIntegration/VisualStudioAbstraction.cs
+++ b/VSIX/RapidXaml.Shared/VisualStudioIntegration/VisualStudioAbstraction.cs
@@ -43,7 +43,6 @@ namespace RapidXamlToolkit.VisualStudioIntegration
             return this.Dte.ActiveDocument.FullName;
         }
 
-        // TODO ISSUE#369 Cache this lookup based on project.FileName
         public ProjectType GetProjectType(EnvDTE.Project project)
         {
             const string WpfGuid = "{60DC8134-EBA5-43B8-BCC9-BB4BC16C2548}";


### PR DESCRIPTION
This PR relates to Issue #163

**Description**  
<!-- Please provide a brief description of what's being committed. -->
Support the ability to use existing UWP methods to check for and report hard-coded attributes

**Confirm**
- [x] Everything builds in 'Release` mode
-  Docs updated
-  Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
-  If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



