### PR TITLE
Avoid NRE due to comment as child of attribute

### DIFF
--- a/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/RapidXamlElementExtractor.cs
+++ b/VSIX/RapidXaml.AnalysisCore/XamlAnalysis/RapidXamlElementExtractor.cs
@@ -176,10 +176,20 @@ namespace RapidXamlToolkit.XamlAnalysis
 
                                                 foreach (var acListChild in acList.ChildNodes)
                                                 {
-                                                    children.Add(
-                                                        GetElementInternal(
+                                                    if (acListChild is XmlCommentSyntax)
+                                                    {
+                                                        // Don't add a null child entry for comments (as comments are currently ignored)
+                                                        continue;
+                                                    }
+
+                                                    var newElement = GetElementInternal(
                                                             xaml.Substring(acListChild.SpanStart, acListChild.Width),
-                                                            startOffset + acListChild.SpanStart));
+                                                            startOffset + acListChild.SpanStart);
+
+                                                    if (newElement != null)
+                                                    {
+                                                        children.Add(newElement);
+                                                    }
                                                 }
 
                                                 result.AddChildrenAttribute(

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXamlElement.cs
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXamlElement.cs
@@ -426,7 +426,7 @@ namespace RapidXaml
                       || c.Name.EndsWith($":{name}", StringComparison.InvariantCultureIgnoreCase))
                 || this.Attributes.Any(
                     a => !a.HasStringValue
-                      && a.Children.Any(c => c.ContainsDescendant(name)));
+                      && a.Children.Any(c => c?.ContainsDescendant(name) ?? false));
         }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RapidXamlElementExtractorTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RapidXamlElementExtractorTests.cs
@@ -1776,5 +1776,22 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
 
             Assert.AreNotEqual(first.Children.Last().Location.Start, second.Children.Last().Location.Start);
         }
+
+        [TestMethod]
+        public void EnsureCommentsAreIgnoredInAttributeChildren()
+        {
+            var xaml = @"
+        <muxc:TwoPaneView>
+            <muxc:TwoPaneView.Pane1>
+                <!-- something important -->
+                <Grid />
+            </muxc:TwoPaneView.Pane1>
+            <muxc:TwoPaneView.Pane2 />
+        </muxc:TwoPaneView>";
+
+            var sut = RapidXamlElementExtractor.GetElement(xaml);
+
+            Assert.AreEqual(1, sut.Attributes[0].Children.Count);
+        }
     }
 }

--- a/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RealWorldIssues.cs
+++ b/VSIX/RapidXamlToolkit.Tests/XamlAnalysis/RealWorldIssues.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RapidXaml;
+using RapidXaml.TestHelpers;
 using RapidXamlToolkit.XamlAnalysis;
 using RapidXamlToolkit.XamlAnalysis.Processors;
 
@@ -302,6 +303,38 @@ namespace RapidXamlToolkit.Tests.XamlAnalysis
             var element = XamlElementProcessor.GetSubElementAtPosition(ProjectType.Wpf, "testFile.xaml", new FakeTextSnapshot(), xaml.Replace("☆", string.Empty), offset, new DefaultTestLogger(), string.Empty, new TestVisualStudioAbstraction());
 
             Assert.IsNotNull(element);
+        }
+
+        [TestMethod]
+        public void Issue455()
+        {
+            var xaml = @"
+        <muxc:TwoPaneView
+            x:Name=""TwoPaneContent""
+            Grid.Column=""1""
+            Margin=""40,0,0,0""
+            MinTallModeHeight=""Infinity""
+            MinWideModeWidth=""Infinity""
+            ModeChanged=""OnTwoPaneViewModeChanged"">
+            <muxc:TwoPaneView.Pane1>
+                <!-- Grid necessary because of ContentFrame1 using deferred loaded -->
+                <Grid Margin=""0,32,0,0"">
+                    <Frame x:Name=""ContentFrame1"" x:Load=""True"" />
+                </Grid>
+            </muxc:TwoPaneView.Pane1>
+            <muxc:TwoPaneView.Pane2>
+                <!-- Grid necessary because of ContentFrame2 using deferred loaded -->
+                <Grid>
+                    <Frame x:Name=""ContentFrame2"" x:Load=""False"" />
+                </Grid>
+            </muxc:TwoPaneView.Pane2>
+        </muxc:TwoPaneView>";
+
+            var sut = CustomAnalysisTestHelper.StringToElement(xaml);
+
+            var actual = sut.ContainsDescendant("TwoPaneView");
+
+            Assert.IsFalse(actual);
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR relates to Issue #455

**Description**  
<!-- Please provide a brief description of what's being committed. -->
prevent a NullReferenceException when looking at the descendants of attributes that contained comments in the original xaml.

**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [ ] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



