### PR TITLE
Update dependencies and min VS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - Expanded ability to show FontAwesome icon previews within the editor.
+- Minimum supported VS version to 16.9.
 
 ## 0.12.2
 

--- a/Templates/RapidXaml.Templates/RapidXaml.Templates.csproj
+++ b/Templates/RapidXaml.Templates/RapidXaml.Templates.csproj
@@ -96,7 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.0.206</Version>
+      <Version>16.10.31321.278</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
       <Version>16.2.29116.78</Version>

--- a/Templates/RapidXaml.Templates/source.extension.vsixmanifest
+++ b/Templates/RapidXaml.Templates/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Templates</DisplayName>
-    <Description xml:space="preserve">Project and item templates to help with XAML development.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/custom-analysis.md</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlTemplatesLogo.png</Icon>
-    <Tags>XAML</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CustomAnalysisItemTemplate" d:TargetPath="|CustomAnalysisItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CustomAnalysisProjectTemplate.zip" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.Templates.bde4c7e5-6e5b-40e7-9335-9c3454b1eb11" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Templates</DisplayName>
+        <Description xml:space="preserve">Project and item templates to help with XAML development.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/custom-analysis.md</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlTemplatesLogo.png</Icon>
+        <Tags>XAML</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CustomAnalysisItemTemplate" d:TargetPath="|CustomAnalysisItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CustomAnalysisProjectTemplate.zip" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/.editorconfig
+++ b/VSIX/.editorconfig
@@ -29,3 +29,6 @@ dotnet_diagnostic.SA1602.severity = none
 [*.{cs}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+
+# CS8032: An instance of analyzer RapidXaml.InternalAnalyzers.RapidXamlInternalAnalyzersAnalyzer cannot be created from C:\Users\matt\Documents\GitHub\mrlacey-RXT\VSIX\RapidXaml.InternalAnalyzers\RapidXaml.InternalAnalyzers\bin\Debug\netstandard2.0\RapidXaml.InternalAnalyzers.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=3.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified..
+dotnet_diagnostic.CS8032.severity = silent

--- a/VSIX/.editorconfig
+++ b/VSIX/.editorconfig
@@ -31,4 +31,4 @@ dotnet_diagnostic.SA1602.severity = none
 dotnet_sort_system_directives_first = true
 
 # CS8032: An instance of analyzer RapidXaml.InternalAnalyzers.RapidXamlInternalAnalyzersAnalyzer cannot be created from C:\Users\matt\Documents\GitHub\mrlacey-RXT\VSIX\RapidXaml.InternalAnalyzers\RapidXaml.InternalAnalyzers\bin\Debug\netstandard2.0\RapidXaml.InternalAnalyzers.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=3.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified..
-dotnet_diagnostic.CS8032.severity = silent
+dotnet_diagnostic.CS8032.severity = none

--- a/VSIX/Benchmarking/Benchmarking.csproj
+++ b/VSIX/Benchmarking/Benchmarking.csproj
@@ -14,9 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.1.89" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.10.230" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.10.34" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,6 +46,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Update="files\A11yTabIndex.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/VSIX/Benchmarking/Benchmarking.csproj
+++ b/VSIX/Benchmarking/Benchmarking.csproj
@@ -15,10 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.10.230" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.10.34" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.9.244" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.9.33" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
   </ItemGroup>
 

--- a/VSIX/Benchmarking/app.config
+++ b/VSIX/Benchmarking/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/VSIX/Benchmarking/app.config
+++ b/VSIX/Benchmarking/app.config
@@ -2,10 +2,18 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-16.7.16" newVersion="16.7.16" />
+        </dependentAssembly>
+        <dependentAssembly>
+            <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-16.9.0.0" newVersion="16.9.0.0" />
+        </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/VSIX/BuildAnalysisUwpTestApp/BuildAnalysisUwpTestApp.csproj
+++ b/VSIX/BuildAnalysisUwpTestApp/BuildAnalysisUwpTestApp.csproj
@@ -151,7 +151,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="RapidXaml.BuildAnalysis">
       <Version>0.1.55</Version>

--- a/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
+++ b/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
@@ -244,30 +244,37 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Data">
-      <Version>16.1.89</Version>
+      <Version>16.10.230</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0">
-      <Version>12.0.30112</Version>
+      <Version>16.10.31320.204</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
+++ b/VSIX/RapidXaml.Analysis/RapidXaml.Analysis.csproj
@@ -248,38 +248,38 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31425.357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Data">
-      <Version>16.10.230</Version>
+      <Version>16.9.244</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0">
-      <Version>16.10.31320.204</Version>
+      <Version>16.9.31023.347</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="RapidXaml.CustomAnalysis">
       <Version>0.12.0</Version>

--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/BaseSuggestedAction.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Actions/BaseSuggestedAction.cs
@@ -67,7 +67,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
 
         public virtual Task<object> GetPreviewAsync(CancellationToken cancellationToken)
         {
-            return null;
+            return Task.FromResult<object>(null);
         }
 
         public void Invoke(CancellationToken cancellationToken)
@@ -128,7 +128,9 @@ namespace RapidXamlToolkit.XamlAnalysis.Actions
         }
 
         // Call this after having made the change if need to force reevaluation of actions
+#pragma warning disable IDE0051 // Remove unused private members
         private void RaiseBufferChange()
+#pragma warning restore IDE0051 // Remove unused private members
         {
             // Adding and deleting a char in order to force taggers re-evaluation
             string text = " ";

--- a/VSIX/RapidXaml.Analysis/app.config
+++ b/VSIX/RapidXaml.Analysis/app.config
@@ -4,15 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="1.5.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VSIX/RapidXaml.Analysis/app.config
+++ b/VSIX/RapidXaml.Analysis/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.11.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Analysis</DisplayName>
-    <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlAnalysisLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Analysis</DisplayName>
+        <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlAnalysisLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />

--- a/VSIX/RapidXaml.AnalysisCore/RapidXaml.AnalysisCore.csproj
+++ b/VSIX/RapidXaml.AnalysisCore/RapidXaml.AnalysisCore.csproj
@@ -78,7 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="RapidXaml.CustomAnalysis">
       <Version>0.12.0</Version>

--- a/VSIX/RapidXaml.AnalysisExe/App.config
+++ b/VSIX/RapidXaml.AnalysisExe/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.11.0.0" newVersion="3.9.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+</configuration>

--- a/VSIX/RapidXaml.AnalysisExe/BuildAnalysisTextSnapshot.cs
+++ b/VSIX/RapidXaml.AnalysisExe/BuildAnalysisTextSnapshot.cs
@@ -45,6 +45,7 @@ namespace RapidXaml.AnalysisExe
             return (line.StartPosition, line.LineNumber);
         }
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public string GetText(int startIndex, int length)
         {
             return string.Empty;
@@ -72,6 +73,7 @@ namespace RapidXaml.AnalysisExe
         public void Write(TextWriter writer)
         {
         }
+#pragma warning restore IDE0060 // Remove unused parameter
 
         public string GetLineTextFromLineNumber(int lineNo)
         {

--- a/VSIX/RapidXaml.AnalysisExe/BuildAnalysisVisualStudioAbstraction.cs
+++ b/VSIX/RapidXaml.AnalysisExe/BuildAnalysisVisualStudioAbstraction.cs
@@ -42,7 +42,9 @@ namespace RapidXaml.AnalysisExe
             throw new NotImplementedException();
         }
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public string GetNameProjectContainingFile(string fileName)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
             return this.projFile;
         }
@@ -57,7 +59,9 @@ namespace RapidXaml.AnalysisExe
             return (this.projFile, this.projectType);
         }
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public ProjectType GetProjectType(EnvDTE.Project project)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
             return ProjectType.Any;
         }

--- a/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
+++ b/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\RapidXaml.Utils\RapidXaml.Utils.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.1.89" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.10.230" />
     <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.12.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
+++ b/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;ANALYSISEXE</DefineConstants>
   </PropertyGroup>
+    <PropertyGroup>
+        <NoWarn>NU1608,SA1600</NoWarn>
+    </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\RapidXaml.Analysis\ErrorList\**" />
     <Compile Include="..\RapidXaml.Analysis\XamlAnalysis\**" />
@@ -22,16 +25,17 @@
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\RapidXaml.Analysis\app.config" Link="app.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\RapidXaml.AnalysisCore\RapidXaml.AnalysisCore.csproj" />
     <ProjectReference Include="..\RapidXaml.Resources\RapidXaml.Resources.csproj" />
     <ProjectReference Include="..\RapidXaml.Shared\RapidXaml.Shared.csproj" />
     <ProjectReference Include="..\RapidXaml.Utils\RapidXaml.Utils.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.10.230" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="3.9.0-3.21056.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="3.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.9.244" />
     <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.12.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
+++ b/VSIX/RapidXaml.AnalysisExe/RapidXaml.AnalysisExe.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="3.9.0-3.21056.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="3.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="16.9.31425.357" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.9.244" />
     <PackageReference Include="RapidXaml.CustomAnalysis" Version="0.12.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.csproj
+++ b/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.csproj
@@ -18,6 +18,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;AUTOFIX</DefineConstants>
   </PropertyGroup>
+    <PropertyGroup>
+        <NoWarn>NU1608</NoWarn>
+    </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\GlobalSuppressions.cs">
       <Link>GlobalSuppressions.cs</Link>

--- a/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.nuspec
+++ b/VSIX/RapidXaml.AutoFix/RapidXaml.AutoFix.nuspec
@@ -14,7 +14,7 @@
     <summary>Apply automatic changes to XAML files.</summary>
     <releaseNotes>.</releaseNotes>
     <copyright>© 2021 Matt Lacey Ltd.</copyright>
-    <tags>XAML, WinUI, UWP, WPF, Xamarin.Forms, MVVM, UNO, MAUI</tags>
+    <tags>XAML, MAUI, MVVM, UNO, UWP, WinUI, WPF, Xamarin.Forms</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="RapidXaml.CustomAnalysis" version="0.12.0" exclude="Build,Analyzers" />

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
@@ -26,8 +26,8 @@
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.csproj
@@ -26,8 +26,8 @@
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
@@ -9,7 +9,7 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\icon.png</icon>
-    <tags>XAML, UWP, WPF, Xamarin.Forms, Uno</tags>
+    <tags>XAML, MAUI, MVVM, UNO, UWP, WinUI, WPF, Xamarin.Forms</tags>
     <description>Run Rapid XAML Analysis checks on all *.xaml files when building a project.</description>
     <releaseNotes>.</releaseNotes>
     <projectUrl>https://rapidxaml.dev</projectUrl>

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
@@ -31,6 +31,8 @@
     <file src=".\bin\release\net472\RapidXaml.BuildAnalysis.pdb" target="tools/net472/" />
     <file src=".\bin\release\net472\RapidXaml.CustomAnalysis.dll" target="tools/net472/" />
     <!-- <file src=".\bin\release\net472\RapidXaml.CustomAnalysis.pdb" target="tools/net472/" /> -->
+    <file src=".\bin\release\net472\RapidXaml.Resources.dll" target="tools/net472/" />
+    <file src=".\bin\release\net472\RapidXaml.Resources.pdb" target="tools/net472/" />
     <file src=".\bin\release\net472\RapidXaml.Shared.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\RapidXaml.Shared.dll.config" target="tools/net472/" />
     <file src=".\bin\release\net472\RapidXaml.Shared.pdb" target="tools/net472/" />
@@ -59,6 +61,7 @@
     <file src=".\bin\release\net472\Microsoft.VisualStudio.OLE.Interop.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.RemoteControl.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.dll" target="tools/net472/" />
+    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Framework.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Telemetry.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Text.Data.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Text.Logic.dll" target="tools/net472/" />

--- a/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
+++ b/VSIX/RapidXaml.BuildAnalysis/RapidXaml.BuildAnalysis.nuspec
@@ -40,14 +40,12 @@
     <!-- Would love to do this with wildcards but for some reason it's not working -->
     <file src=".\bin\release\net472\ApiAnalysis.SimpleJsonAnalyzer.vsixuse.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\EnvDTE.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\EnvDTE80.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.ApplicationInsights.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.CSharp.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.CSharp.Workspaces.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.EditorFeatures.Text.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.Features.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.CodeAnalysis.FlowAnalysis.Utilities.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.Scripting.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.VisualBasic.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" target="tools/net472/" />
@@ -60,11 +58,6 @@
     <file src=".\bin\release\net472\Microsoft.VisualStudio.LanguageServices.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.OLE.Interop.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.RemoteControl.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Framework.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.10.0.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.11.0.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.12.0.dll" target="tools/net472/" />
-    <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.8.0.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Shell.Interop.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Telemetry.dll" target="tools/net472/" />
     <file src=".\bin\release\net472\Microsoft.VisualStudio.Text.Data.dll" target="tools/net472/" />

--- a/VSIX/RapidXaml.Common/RapidXaml.Common.csproj
+++ b/VSIX/RapidXaml.Common/RapidXaml.Common.csproj
@@ -63,10 +63,13 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074">
+    <PackageReference Include="Microsoft.VisualStudio.Validation">
+      <Version>16.10.34</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXaml.Common/RapidXaml.Common.csproj
+++ b/VSIX/RapidXaml.Common/RapidXaml.Common.csproj
@@ -63,18 +63,21 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31425.357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Validation">
-      <Version>16.10.34</Version>
+      <Version>16.9.33</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXaml.Common/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Common/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Common Functionality</DisplayName>
-    <Description xml:space="preserve">Common infrastructure used by other extensions that are part of the Rapid XAML Toolkit.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlCommonLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.Common.3cb31872-64f7-49f8-91a7-31393173c5ce" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Common Functionality</DisplayName>
+        <Description xml:space="preserve">Common infrastructure used by other extensions that are part of the Rapid XAML Toolkit.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlCommonLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Common/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Common/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />

--- a/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
+++ b/VSIX/RapidXaml.CustomAnalysis/RapidXaml.CustomAnalysis.nuspec
@@ -14,7 +14,7 @@
     <summary>Create custom XAML analyzers.</summary>
     <releaseNotes>Add support for CreateResource. (Will require VSIX version &gt;= 0.12)</releaseNotes>
     <copyright>Copyright © 2021 Matt Lacey Ltd.</copyright>
-    <tags>XAML, UWP, WPF, Xamarin.Forms, MVVM, UNO, WinUI</tags>
+    <tags>XAML, MAUI, MVVM, UNO, UWP, WinUI, WPF, Xamarin.Forms</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="GuiLabs.Language.Xml" version="1.2.46" exclude="Build,Analyzers" />

--- a/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
+++ b/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
@@ -97,14 +97,20 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31425.357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.VsixSignTool">
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
+++ b/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
@@ -97,12 +97,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/IntraTextAdornmentTagger.cs
+++ b/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/IntraTextAdornmentTagger.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -114,9 +115,12 @@ namespace RapidXaml.EditorExtras.SymbolVisualizer
 
                 if (wasEmpty && this.invalidatedSpans.Count > 0)
                 {
+                    ThreadHelper.JoinableTaskFactory.Run(async () =>
+                    {
 #pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-                    this.view.VisualElement.Dispatcher.BeginInvoke(new Action(this.AsyncUpdate));
+                        await this.view.VisualElement.Dispatcher.BeginInvoke(new Action(this.AsyncUpdate));
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
+                    });
                 }
             }
         }

--- a/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
     </Installation>
     <Dependencies>
     </Dependencies>

--- a/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Editor Extras</DisplayName>
-    <Description xml:space="preserve">Tools to accelerate XAML app development by providing additional features to the Visual Studio editor.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlEditorExtrasLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Dependencies>
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Editor Extras</DisplayName>
+        <Description xml:space="preserve">Tools to accelerate XAML app development by providing additional features to the Visual Studio editor.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlEditorExtrasLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;Roslyn;Analysis</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Dependencies>
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.Generation/Parsers/CodeParserBase.cs
+++ b/VSIX/RapidXaml.Generation/Parsers/CodeParserBase.cs
@@ -430,7 +430,7 @@ namespace RapidXamlToolkit.Parsers
                 rawOutput = rawOutput.Replace(Placeholder.PropertyName, $"{namePrefix}.{Placeholder.PropertyName}");
             }
 
-            return this.FormatOutput(rawOutput, property.PropertyType, property.Name, numericSubstitute, property.Symbol, property.Attributes, getSubPropertyOutput);
+            return this.FormatOutput(rawOutput, property.PropertyType, property.Name, numericSubstitute, property?.Symbol, property.Attributes, getSubPropertyOutput);
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter
@@ -652,7 +652,7 @@ namespace RapidXamlToolkit.Parsers
                 }
             }
 
-            if (result.Contains(Placeholder.EnumMembers))
+            if (result.Contains(Placeholder.EnumMembers) && symbol != null)
             {
                 var enumMembers = symbol.GetMembers().Where(m => m.Kind == SymbolKind.Field && !m.IsImplicitlyDeclared).ToList();
 

--- a/VSIX/RapidXaml.Generation/RapidXaml.Generation.csproj
+++ b/VSIX/RapidXaml.Generation/RapidXaml.Generation.csproj
@@ -188,35 +188,38 @@
       <Version>5.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31425.357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXaml.Generation/RapidXaml.Generation.csproj
+++ b/VSIX/RapidXaml.Generation/RapidXaml.Generation.csproj
@@ -180,6 +180,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -187,24 +188,30 @@
       <Version>5.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;generation</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9,17.0)" />
     </Installation>
     <Dependencies>
     </Dependencies>

--- a/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Generation/source.extension.vsixmanifest
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Generation</DisplayName>
-    <Description xml:space="preserve">Tools to accelerate XAML app development by generating XAML.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlGenerationLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;generation</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
-  </Installation>
-  <Dependencies>
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.Generation.bd250c2a-3aa1-4838-9d3d-c36e956cd8d0" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Generation</DisplayName>
+        <Description xml:space="preserve">Tools to accelerate XAML app development by generating XAML.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlGenerationLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;Forms;MVVM;generation</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2,17.0)" />
+    </Installation>
+    <Dependencies>
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers.csproj
+++ b/VSIX/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" IncludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VSIX/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers.csproj
+++ b/VSIX/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers/RapidXaml.InternalAnalyzers.csproj
@@ -31,8 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" IncludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VSIX/RapidXaml.RoslynAnalyzers/RapidXaml.RoslynAnalyzers.csproj
+++ b/VSIX/RapidXaml.RoslynAnalyzers/RapidXaml.RoslynAnalyzers.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <Version>3.3.2</Version>
@@ -109,27 +109,27 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31425.357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
@@ -137,7 +137,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXaml.RoslynAnalyzers/RapidXaml.RoslynAnalyzers.csproj
+++ b/VSIX/RapidXaml.RoslynAnalyzers/RapidXaml.RoslynAnalyzers.csproj
@@ -101,35 +101,38 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <Version>3.3.0</Version>
+      <Version>3.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML RoslynAnalyzers</DisplayName>
-    <Description xml:space="preserve">Roslyn analyzers to help with XAML app development.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://rapidxaml.dev/roslyn-analyzers</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlRoslynAnalyzersLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXaml.RoslynAnalyzers.c58ca4bd-0d58-46cd-afc3-c47a1e1b8c7f" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML RoslynAnalyzers</DisplayName>
+        <Description xml:space="preserve">Roslyn analyzers to help with XAML app development.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://rapidxaml.dev/roslyn-analyzers</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlRoslynAnalyzersLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.RoslynAnalyzers/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />

--- a/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
+++ b/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
@@ -104,35 +104,38 @@
       <Version>2.17.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <Version>16.10.31321.278</Version>
+      <Version>16.9.31425.357</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">
       <Version>16.3.176</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0">
-      <Version>16.10.31320.204</Version>
+      <Version>16.9.31023.347</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Validation">
-      <Version>16.10.34</Version>
+      <Version>16.9.33</Version>
     </PackageReference>
     <PackageReference Include="Nerdbank.Streams">
       <Version>2.7.74</Version>

--- a/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
+++ b/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
@@ -101,34 +101,47 @@
       <Version>1.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.10.0</Version>
+      <Version>2.17.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <Version>16.0.206</Version>
+      <Version>16.10.31321.278</Version>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">
-      <Version>16.3.2</Version>
+      <Version>16.3.176</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0">
-      <Version>12.0.30112</Version>
+      <Version>16.10.31320.204</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Validation">
+      <Version>16.10.34</Version>
+    </PackageReference>
+    <PackageReference Include="Nerdbank.Streams">
+      <Version>2.7.74</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
-      <Version>5.7.0</Version>
+      <Version>5.10.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
+++ b/VSIX/RapidXaml.Shared/RapidXaml.Shared.csproj
@@ -125,7 +125,7 @@
       <Version>12.0.30112</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
       <Version>5.7.0</Version>

--- a/VSIX/RapidXamlToolkit.Tests.AutoFix/RapidXamlToolkit.Tests.AutoFix.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.AutoFix/RapidXamlToolkit.Tests.AutoFix.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.0.206</Version>
+      <Version>16.10.31321.278</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>2.2.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.2</Version>

--- a/VSIX/RapidXamlToolkit.Tests.AutoFix/RapidXamlToolkit.Tests.AutoFix.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.AutoFix/RapidXamlToolkit.Tests.AutoFix.csproj
@@ -71,16 +71,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.10.31321.278</Version>
+      <Version>16.9.31425.357</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.2.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>2.2.4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/Parsers/ParseRealDocumentsTests.g.cs
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/Parsers/ParseRealDocumentsTests.g.cs
@@ -18,6 +18,1038 @@ namespace RapidXamlToolkit.Tests.Manual.Parsers
     {
         public TestContext TestContext { get; set; }
 
+        [TestMethod]
+        public async Task TestCodeFilesIn_abstractionsxunit()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\abstractions.xunit");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_alwaysuse()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\alwaysuse");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_aniongithubCustomTool()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\aniongithub-CustomTool");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_appmonkeys()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\app-monkeys");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_AppInstallerEditor()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\AppInstallerEditor");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_AspNetCoreDocs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\AspNetCore.Docs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_bible()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\bible");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_botbuildersamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\botbuilder-samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Bravo()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Bravo");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_brewjournal()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\brewjournal");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_cakevs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\cake-vs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_calculator()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\calculator");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CharacterMapUWP()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Character-Map-UWP");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ClearlyEditable()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ClearlyEditable");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_codestories()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\code-stories");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CollapseComments()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CollapseComments");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CommandingUwpDocs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CommandingUwpDocs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CommentLinks()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CommentLinks");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ConstVisualizer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ConstVisualizer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ContentGridMockup()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ContentGridMockup");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CoreTemplateStudio()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CoreTemplateStudio");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CreatingcrossplatformapplicationswithUno()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Creating-cross-platform-applications-with-Uno");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_CrossPlatformTemplateStudio()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CrossPlatformTemplateStudio");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_DemoSnippets()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\DemoSnippets");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_DetectWorkloads()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\DetectWorkloads");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_DontCopyAlways()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\DontCopyAlways");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_dotmortenXamarinForms()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\dotmorten-Xamarin.Forms");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_dotmortenXamarinFormsUWPShellSample()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\dotmorten-Xamarin.Forms.UWPShell.Sample");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_dotnetroslyn()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\dotnet-roslyn");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ErrorHelper()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ErrorHelper");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ErrorHighlighter()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ErrorHighlighter");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_essentialuikitforxamarinforms()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\essential-ui-kit-for-xamarin.forms");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_FestiveEditor()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\FestiveEditor");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Gastropods()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Gastropods");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_GetLiveXamlInfo()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\GetLiveXamlInfo");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ghpkgtest()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ghpkgtest");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_githubappswithgraphql()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\github-apps-with-graphql");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_githubwebhookswithrest()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\github-webhooks-with-rest");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_githubdesktop()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\githubdesktop");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_GitStatusBg()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\GitStatusBg");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_hicknhacksemanticcolorizer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\hicknhack-semantic-colorizer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_HotTips()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\HotTips");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Identity()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Identity");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_imagecomments()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\image-comments");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ImageOptimizer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ImageOptimizer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Infragisticsunosamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Infragistics-uno-samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_InvokeNavigationViewItems()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\InvokeNavigationViewItems");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_IssuesHub()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\IssuesHub");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_janczizikowsleek()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\janczizikow-sleek");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_jcansdaleLocalizeVsix()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\jcansdale-LocalizeVsix");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_kaxaml()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\kaxaml");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_LanguageRef()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\LanguageRef");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_LinkedVsctIssue()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\LinkedVsctIssue");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_LuisEntityHelpers()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\LuisEntityHelpers");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_madskristensenFileIcons()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\madskristensen-FileIcons");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MahAppsMetro()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MahApps.Metro");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MahAppsMetroSimpleChildWindow()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MahApps.Metro.SimpleChildWindow");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Marb2000XamlIslands()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Marb2000XamlIslands");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MarkdownEditor()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MarkdownEditor");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_michaelhawkerXmlSyntaxVisualizerUWP()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\michael-hawker-XmlSyntaxVisualizerUWP");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_microsoftuixaml()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\microsoft-ui-xaml");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_microsoftuixamlnumberbox()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\microsoft-ui-xaml-numberbox");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_microsoftuixamlspecs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\microsoft-ui-xaml-specs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_microsoftwts()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\microsoft-wts");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mlltdUnoReference()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mlltd-UnoReference");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mlltdXamarinReference()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mlltd-XamarinReference");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mrlappmonkeys()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrl-app-monkeys");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mrlmicrosoftuixaml()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrl-microsoft-ui-xaml");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mrlVertiPaqAnalyzer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrl-VertiPaq-Analyzer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mrlaceyRXT()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrlacey-RXT");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MrlaceySnippets()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MrlaceySnippets");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MultiLineStringAnalyzer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MultiLineStringAnalyzer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mvegacaWindowsTemplateStudio()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mvegaca-WindowsTemplateStudio");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_mvegacaWinUISamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mvegaca-WinUISamples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MVVMSamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MVVM-Samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MVVMBasicSnippets()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MVVMBasicSnippets");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MvvmCross()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MvvmCross");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_MyDotNetCoreWpfApp()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MyDotNetCoreWpfApp");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_natemcmastermsbuildtasks()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\natemcmaster-msbuild-tasks");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_natemcmasterYarnMSBuild()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\natemcmaster-Yarn.MSBuild");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_PagesTest()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\PagesTest");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_PowerToys()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\PowerToys");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Prism()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Prism");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_PrivateWindowsTemplateStudio()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Private-WindowsTemplateStudio");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ProjectReunionSamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Project-Reunion-Samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ProjectReunion()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ProjectReunion");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ProWinuiTemplates()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ProWinuiTemplates");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_radeonasmtools()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\radeon-asm-tools");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_RandomXAMLFiles()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Random XAML Files");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_RapidXamlDemos()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\RapidXaml-Demos");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_RapidXamlDev()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\RapidXamlDev");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_RealTimeGraphX()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\RealTimeGraphX");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ReproTreeView()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ReproTreeView");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ResPsuedoLoc()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ResPsuedoLoc");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_rxtdemos()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\rxt-demos");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ShowKeys()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowKeys");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ShowMeTheXAML()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowMeTheXAML");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ShowSelection()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowSelection");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ShowTheShortcut()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowTheShortcut");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_SignVsix()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SignVsix");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_SimpleJsonAnalyzer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SimpleJsonAnalyzer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_SimpleTesting()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SimpleTesting");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_SlnFileDiff()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SlnFileDiff");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_SmartHotel360()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SmartHotel360");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_sqlbiBravo()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\sqlbi-Bravo");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_StringResourceVisualizer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\StringResourceVisualizer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_tempwts3206()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\temp-wts3206");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_tempwts3206e()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\temp-wts3206e");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_terminal()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\terminal");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_testtemplates()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\test-templates");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_tryconvert()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\try-convert");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_TryConvertXaml()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\TryConvertXaml");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Uno()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Uno");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_unobook()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\uno-book");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UnoPlayground()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Uno.Playground");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UnoSkiaSharpExtended()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Uno.SkiaSharp.Extended");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_unobookcodepoc()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\unobookcodepoc");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UnoDeployTest()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UnoDeployTest");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_unoworkshops()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\unoworkshops");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UWPMVVMToolkitSample()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UWP-MVVM-Toolkit-Sample");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UWPCommunityToolkit()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UWPCommunityToolkit");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UWPCommunityToolkitDocs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UWPCommunityToolkitDocs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UwpDesignTimeData()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UwpDesignTimeData");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UwpDevTidy()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UwpDevTidy");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_UwpEssentials()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\UwpEssentials");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VBUWPTemplates()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VB-UWP-Templates");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VBStyleAnalyzer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VBStyleAnalyzer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VertiPaqAnalyzer()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VertiPaq-Analyzer");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VincentHNetCSharpForMarkup()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VincentH-Net-CSharpForMarkup");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_visor()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\visor");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VisualStudioOutputFilterExtension()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VisualStudio-Output-Filter-Extension");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_vscodegitlens()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\vscode-gitlens");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VSConsole()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VSConsole");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VsctIntellisense()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VsctIntellisense");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VsEditorExtensions()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VsEditorExtensions");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VsixCommon()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VsixCommon");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VsixTools()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VsixTools");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VSSDKExtensibilitySamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VSSDK-Extensibility-Samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_VSWaterMark()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VSWaterMark");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WarnAboutTodos()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WarnAboutTodos");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WCTMVVMSamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WCT-MVVM-Samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Win2DSamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Win2D-Samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Windowsappsamplecustomersordersdatabase()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Windows-appsample-customers-orders-database");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_Windowsappsamplelunchscheduler()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Windows-appsample-lunch-scheduler");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WindowsappsampleXamlHosting()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Windows-appsample-Xaml-Hosting");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_windowsuwp()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\windows-uwp");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WindowsCommunityToolkitwiki()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WindowsCommunityToolkit-wiki");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WindowsTemplateStudio()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WindowsTemplateStudio");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WindowsTestHelpers()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WindowsTestHelpers");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_winforms()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\winforms");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_wingetpkgs()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\winget-pkgs");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WinUI3Demos()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WinUI-3-Demos");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WinUIEssentials()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WinUI-Essentials");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_wpf()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\wpf");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WTSXamarinFormsPreview()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WTS-Xamarin-Forms-Preview");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_WTSXamarinFormsPreviewfork()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WTS-Xamarin-Forms-Preview-fork");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_wts3206d()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\wts3206d");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_wts3206e()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\wts3206e");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_xamarinformssamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xamarin-forms-samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamarinEssentials()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Xamarin.Essentials");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamarinForms()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Xamarin.Forms");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamarinFormsUWPShellSample()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Xamarin.Forms.UWPShell.Sample");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamarinCommunityToolkit()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamarinCommunityToolkit");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_xamlbindingtool()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xaml-binding-tool");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamlControlsGallery()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Xaml-Controls-Gallery");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_xamldesignerextensibilitysamples()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xaml-designer-extensibility-samples");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamlBenchmark()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamlBenchmark");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamlIntellisenseLimitationExample()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamlIntellisenseLimitationExample");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_XamlIslandBlogPostSample()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamlIslandBlogPostSample");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_xunit()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xunit");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_ZenCodingVS()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ZenCodingVS");
+        }
+
+        [TestMethod]
+        public async Task TestCodeFilesIn_miscFiles()
+        {
+            await this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\_miscFiles");
+        }
+
         private static IEnumerable<string> GetCodeFiles(string folder)
         {
             foreach (var file in Directory.GetFiles(folder, "*.cs", SearchOption.AllDirectories))

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -84,16 +84,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
       <Version>16.10.230</Version>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/RapidXamlToolkit.Tests.Manual.csproj
@@ -84,19 +84,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic">
-      <Version>16.1.89</Version>
+      <Version>16.10.230</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.4.0</Version>
+      <Version>2.2.4</Version>
     </PackageReference>
     <PackageReference Include="RapidXaml.CustomAnalysis">
       <Version>0.12.0</Version>

--- a/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/ParseRealDocumentsTests.g.cs
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/XamlAnalysis/ParseRealDocumentsTests.g.cs
@@ -42,6 +42,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_AppInstallerEditor()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\AppInstallerEditor");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_AspNetCoreDocs()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\AspNetCore.Docs");
@@ -60,15 +66,33 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_Bravo()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Bravo");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_brewjournal()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\brewjournal");
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_cakevs()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\cake-vs");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_calculator()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\calculator");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_CharacterMapUWP()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Character-Map-UWP");
         }
 
         [TestMethod]
@@ -117,6 +141,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_CoreTemplateStudio()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\CoreTemplateStudio");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_CreatingcrossplatformapplicationswithUno()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Creating-cross-platform-applications-with-Uno");
         }
 
         [TestMethod]
@@ -180,6 +210,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_FestiveEditor()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\FestiveEditor");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_Gastropods()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Gastropods");
@@ -189,6 +225,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_GetLiveXamlInfo()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\GetLiveXamlInfo");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_ghpkgtest()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ghpkgtest");
         }
 
         [TestMethod]
@@ -246,6 +288,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_Infragisticsunosamples()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Infragistics-uno-samples");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_InvokeNavigationViewItems()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\InvokeNavigationViewItems");
@@ -270,6 +318,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_kaxaml()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\kaxaml");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_LanguageRef()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\LanguageRef");
@@ -291,6 +345,18 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_madskristensenFileIcons()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\madskristensen-FileIcons");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_MahAppsMetro()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MahApps.Metro");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_MahAppsMetroSimpleChildWindow()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MahApps.Metro.SimpleChildWindow");
         }
 
         [TestMethod]
@@ -336,6 +402,18 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_mlltdUnoReference()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mlltd-UnoReference");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_mlltdXamarinReference()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mlltd-XamarinReference");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_mrlappmonkeys()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrl-app-monkeys");
@@ -348,15 +426,33 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_mrlVertiPaqAnalyzer()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrl-VertiPaq-Analyzer");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_mrlaceyRXT()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mrlacey-RXT");
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_MrlaceySnippets()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MrlaceySnippets");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_MultiLineStringAnalyzer()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\MultiLineStringAnalyzer");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_mvegacaWindowsTemplateStudio()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\mvegaca-WindowsTemplateStudio");
         }
 
         [TestMethod]
@@ -414,6 +510,36 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_Prism()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Prism");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_PrivateWindowsTemplateStudio()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Private-WindowsTemplateStudio");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_ProjectReunionSamples()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Project-Reunion-Samples");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_ProjectReunion()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ProjectReunion");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_ProWinuiTemplates()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ProWinuiTemplates");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_radeonasmtools()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\radeon-asm-tools");
@@ -468,6 +594,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_ShowMeTheXAML()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowMeTheXAML");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_ShowSelection()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ShowSelection");
@@ -507,6 +639,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_SmartHotel360()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\SmartHotel360");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_sqlbiBravo()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\sqlbi-Bravo");
         }
 
         [TestMethod]
@@ -558,9 +696,27 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_unobook()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\uno-book");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_UnoPlayground()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Uno.Playground");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_UnoSkiaSharpExtended()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Uno.SkiaSharp.Extended");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_unobookcodepoc()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\unobookcodepoc");
         }
 
         [TestMethod]
@@ -624,6 +780,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_VertiPaqAnalyzer()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VertiPaq-Analyzer");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_VincentHNetCSharpForMarkup()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VincentH-Net-CSharpForMarkup");
@@ -636,9 +798,21 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_VisualStudioOutputFilterExtension()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VisualStudio-Output-Filter-Extension");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_vscodegitlens()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\vscode-gitlens");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_VSConsole()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\VSConsole");
         }
 
         [TestMethod]
@@ -720,6 +894,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_WindowsCommunityToolkitwiki()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WindowsCommunityToolkit-wiki");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_WindowsTemplateStudio()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WindowsTemplateStudio");
@@ -744,6 +924,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_WinUI3Demos()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WinUI-3-Demos");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_WinUIEssentials()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WinUI-Essentials");
@@ -759,6 +945,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_WTSXamarinFormsPreview()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WTS-Xamarin-Forms-Preview");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_WTSXamarinFormsPreviewfork()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\WTS-Xamarin-Forms-Preview-fork");
         }
 
         [TestMethod]
@@ -798,6 +990,18 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         }
 
         [TestMethod]
+        public void TestXamlFilesIn_XamarinCommunityToolkit()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamarinCommunityToolkit");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_xamlbindingtool()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xaml-binding-tool");
+        }
+
+        [TestMethod]
         public void TestXamlFilesIn_XamlControlsGallery()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\Xaml-Controls-Gallery");
@@ -807,6 +1011,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_xamldesignerextensibilitysamples()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xaml-designer-extensibility-samples");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_XamlBenchmark()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\XamlBenchmark");
         }
 
         [TestMethod]
@@ -825,6 +1035,12 @@ namespace RapidXamlToolkit.Tests.Manual.XamlAnalysis
         public void TestXamlFilesIn_xunit()
         {
             this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\xunit");
+        }
+
+        [TestMethod]
+        public void TestXamlFilesIn_ZenCodingVS()
+        {
+            this.CanParseWithoutErrors(@"C:\Users\matt\Documents\GitHub\ZenCodingVS");
         }
 
         [TestMethod]

--- a/VSIX/RapidXamlToolkit.Tests.Manual/app.config
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
           <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
           <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/VSIX/RapidXamlToolkit.Tests.Manual/app.config
+++ b/VSIX/RapidXamlToolkit.Tests.Manual/app.config
@@ -3,8 +3,12 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
+          <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+          <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -16,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -200,7 +200,7 @@
       <Version>1.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <Version>3.3.2</Version>
@@ -208,22 +208,25 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.10.0-4.21318.11</Version>
+      <Version>3.9.0-3.21056.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.10.0</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.10.31321.278</Version>
+      <Version>16.9.31425.357</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.2.4</Version>

--- a/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
+++ b/VSIX/RapidXamlToolkit.Tests/RapidXamlToolkit.Tests.csproj
@@ -200,30 +200,36 @@
       <Version>1.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <Version>3.3.0</Version>
+      <Version>3.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost">
-      <Version>3.5.0-beta3-20074-03</Version>
+      <Version>3.10.0-4.21318.11</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common">
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.2.0</Version>
+      <Version>3.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.0.206</Version>
+      <Version>16.10.31321.278</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>2.2.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>2.2.4</Version>
     </PackageReference>
     <PackageReference Include="RapidXaml.CustomAnalysis">
       <Version>0.12.0</Version>

--- a/VSIX/RapidXamlToolkit.Tests/app.config
+++ b/VSIX/RapidXamlToolkit.Tests/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
           <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
           <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/VSIX/RapidXamlToolkit.Tests/app.config
+++ b/VSIX/RapidXamlToolkit.Tests/app.config
@@ -3,8 +3,12 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.2.0.0" />
+          <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+          <assemblyIdentity name="Microsoft.CodeAnalysis.InteractiveHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-3.10.0.0" newVersion="3.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -16,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -110,15 +110,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <Version>3.3.0</Version>
+      <Version>3.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <Version>16.0.206</Version>
+      <Version>16.10.31321.278</Version>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Validation">
+      <Version>16.10.34</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>16.2.3074</Version>
+      <Version>16.9.1050</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
+++ b/VSIX/RapidXamlToolkit/RapidXamlToolkit.csproj
@@ -115,11 +115,14 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <Version>16.10.31321.278</Version>
+      <Version>16.9.31425.357</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data">
+      <Version>16.9.244</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Validation">
-      <Version>16.10.34</Version>
+      <Version>16.9.33</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>16.9.1050</Version>
@@ -127,7 +130,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>16.3.29220.27</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
-    <DisplayName>Rapid XAML Toolkit</DisplayName>
-    <Description xml:space="preserve">Tools to accelerate XAML app development.</Description>
-    <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
-    <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\RapidXamlToolkitLogo.png</Icon>
-    <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="RapidXamlToolkit.0dc8e86a-836b-47e5-aa3f-f5e71c15e37a" Version="0.12.2" Language="en-US" Publisher="Matt Lacey" />
+        <DisplayName>Rapid XAML Toolkit</DisplayName>
+        <Description xml:space="preserve">Tools to accelerate XAML app development.</Description>
+        <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>
+        <License>LICENSE.txt</License>
+        <GettingStartedGuide>https://github.com/mrlacey/Rapid-XAML-Toolkit/tree/main/docs</GettingStartedGuide>
+        <ReleaseNotes>https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\RapidXamlToolkitLogo.png</Icon>
+        <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>

--- a/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
+++ b/VSIX/RapidXamlToolkit/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>XAML;UWP;WPF;Xamarin.Forms;Uno;MVVM</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.2, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This PR relates to Issue #447

**Description**  
<!-- Please provide a brief description of what's being committed. -->
Set minimum supported VS version to 16.9
Update VS and Roslyn related package dependencies

**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



