### PR TITLE
Add visualizers for Icon in NavigationViewItem (UWP & WinUI)

### DIFF
--- a/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
+++ b/VSIX/RapidXaml.EditorExtras/RapidXaml.EditorExtras.csproj
@@ -62,6 +62,8 @@
     <Compile Include="SymbolVisualizer\GlyphTagger.cs" />
     <Compile Include="SymbolVisualizer\GlyphTaggerProvider.cs" />
     <Compile Include="SymbolVisualizer\IntraTextAdornmentTagger.cs" />
+    <Compile Include="SymbolVisualizer\NavigationViewTagger.cs" />
+    <Compile Include="SymbolVisualizer\NavigationViewTaggerProvider.cs" />
     <Compile Include="SymbolVisualizer\RegexTagger.cs" />
     <Compile Include="SymbolVisualizer\SymbolIconAdornment.cs" />
     <Compile Include="SymbolVisualizer\SymbolIconAdornmentTagger.cs" />

--- a/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/NavigationViewTagger.cs
+++ b/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/NavigationViewTagger.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Matt Lacey Ltd. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Text;
+
+namespace RapidXaml.EditorExtras.SymbolVisualizer
+{
+    internal sealed class NavigationViewTagger : SymbolIconRegexTagger
+    {
+        internal NavigationViewTagger(ITextBuffer buffer)
+            : base(buffer, @"(Icon="")([a-z2]{2,})("")")
+        {
+        }
+
+        protected override SymbolIconTag TryCreateTagForMatch(Match match, int lineStart, int spanStart, string snapshotText)
+        {
+            return this.TryCreateSymbolIconTagForMatch(match, lineStart, spanStart, snapshotText, SymbolType.Symbol, "NavigationViewItem");
+        }
+    }
+}

--- a/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/NavigationViewTaggerProvider.cs
+++ b/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/NavigationViewTaggerProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Matt Lacey Ltd. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
+using RapidXamlToolkit;
+
+namespace RapidXaml.EditorExtras.SymbolVisualizer
+{
+    [Export(typeof(ITaggerProvider))]
+    [ContentType(KnownContentTypes.Xaml)]
+    [TagType(typeof(SymbolIconTag))]
+    internal sealed class NavigationViewTaggerProvider : ITaggerProvider
+    {
+        public ITagger<T> CreateTagger<T>(ITextBuffer buffer)
+            where T : ITag
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            return buffer.Properties.GetOrCreateSingletonProperty(() => new NavigationViewTagger(buffer)) as ITagger<T>;
+        }
+    }
+}


### PR DESCRIPTION
This PR relates to Issue #

**Description**  
<!-- Please provide a brief description of what's being committed. -->

Enables the visualization of icons used in `NavigationViewItem`s

![image](https://user-images.githubusercontent.com/189547/125818308-5a6c7564-59d7-443f-bd97-0b89e207a21e.png)


**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [ ] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



