### PR TITLE
Support short versions of RowDefinitions and ColumnDefinitions for all project types

### DIFF
--- a/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/GridProcessor.cs
+++ b/VSIX/RapidXaml.Analysis/XamlAnalysis/Processors/GridProcessor.cs
@@ -41,7 +41,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             string rowDefsString = null;
 
-            if (rowDefPos < 0 && (this.ProjectType.Matches(ProjectType.XamarinForms) || this.ProjectType.Matches(ProjectType.MAUI)))
+            if (rowDefPos < 0)
             {
                 // See if using new inline format
                 if (this.TryGetAttribute(xamlElement, Attributes.RowDefinitions, AttributeType.Inline, out _, out _, out _, out rowDefsString))
@@ -60,7 +60,7 @@ namespace RapidXamlToolkit.XamlAnalysis.Processors
 
             string colDefsString = null;
 
-            if (colDefPos < 0 && (this.ProjectType.Matches(ProjectType.XamarinForms) || this.ProjectType.Matches(ProjectType.MAUI)))
+            if (colDefPos < 0)
             {
                 // See if using new inline format
                 if (this.TryGetAttribute(xamlElement, Attributes.ColumnDefinitions, AttributeType.Inline, out _, out _, out _, out colDefsString))


### PR DESCRIPTION

This PR relates to Issue #493

**Description**  
<!-- Please provide a brief description of what's being committed. -->

remove the ProjectType check as it's only UWP that doesn't support this and it was starting to feel like an unnecessary optimization


**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [ ] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [ ] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



