### PR TITLE
Nested grid whitespace issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Upcoming
 
-- [See what's planned](https://github.com/mrlacey/Rapid-XAML-Toolkit/milestone/12)
+- [See what's planned next](https://github.com/mrlacey/Rapid-XAML-Toolkit/milestone/12)
+
+## 0.13.1
+
+- Fix analysis issue with nested grids.
 
 ## 0.13.0
 

--- a/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
+++ b/VSIX/RapidXaml.Analysis/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.13.0.0")]
-[assembly: AssemblyFileVersion("0.13.0.0")]
+[assembly: AssemblyVersion("0.13.1.0")]
+[assembly: AssemblyFileVersion("0.13.1.0")]
 
 ////[assembly: InternalsVisibleTo(
 ////    "RapidXamlToolkit.Tests, PublicKey=" +

--- a/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
+++ b/VSIX/RapidXaml.Analysis/RapidXamlAnalysisPackage.cs
@@ -21,7 +21,7 @@ namespace RapidXamlToolkit
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.13.0")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.13.1")] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(RapidXamlAnalysisPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(AnalysisOptionsGrid), "Rapid XAML", "Analysis", 106, 107, true)]

--- a/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.Analysis/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.13.0" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.Analysis.09349b25-a606-429c-ac92-8d4acf027e25" Version="0.13.1" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Analysis</DisplayName>
     <Description xml:space="preserve">Tools to accelerate XAML app development by providing analysis and code fixes.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>

--- a/VSIX/RapidXamlToolkit.Tests/Grid/MissingDefinitionsTests.cs
+++ b/VSIX/RapidXamlToolkit.Tests/Grid/MissingDefinitionsTests.cs
@@ -297,6 +297,40 @@ namespace RapidXamlToolkit.Tests.Grid
             Assert.AreEqual(1, actualTags.OfType<MissingRowDefinitionTag>().Count());
         }
 
+        [TestMethod]
+        public void ConciseSyntaxWithMultipleChildGrids_ColumnDefinitions()
+        {
+            var xaml = @"<Grid ColumnDefinitions=""*,*"">
+    <Grid ColumnDefinitions=""*,*"" />
+    <Grid
+        ColumnDefinitions=""*,*,*,*,*"">
+        <Button Grid.Column=""3"" />
+        <Button Grid.Column=""4"" />
+    </Grid>
+</Grid>";
+
+            var actualTags = this.ProcessGrid(xaml);
+
+            Assert.AreEqual(0, actualTags.OfType<MissingColumnDefinitionTag>().Count());
+        }
+
+        [TestMethod]
+        public void ConciseSyntaxWithMultipleChildGrids_RowDefinitions()
+        {
+            var xaml = @"<Grid RowDefinitions=""*,*"">
+    <Grid RowDefinitions=""*,*"" />
+    <Grid
+      RowDefinitions=""*,*,*,*,*"">
+        <Button Grid.Row=""3"" />
+        <Button Grid.Row=""4"" />
+    </Grid>
+</Grid>";
+
+            var actualTags = this.ProcessGrid(xaml);
+
+            Assert.AreEqual(0, actualTags.OfType<MissingRowDefinitionTag>().Count());
+        }
+
         private List<IRapidXamlAdornmentTag> ProcessGrid(string xaml)
         {
             var outputTags = new TagList();


### PR DESCRIPTION
This PR relates to Issue #-

**Description**  
<!-- Please provide a brief description of what's being committed. -->

Nested grid that have a new line (rather than a space) immediately after "<Grid" weren't being picked up in the exclusions of nested grids.
This means that nested column and row definitions could be (were being) reported as unspecified when they are.


**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [x] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->

n/a

