### PR TITLE
I495 editor UI lock issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.13.1
 
 - Fix analysis issue with nested grids.
+- Fix editor issue that could lock the VS main thread.
 
 ## 0.13.0
 

--- a/VSIX/RapidXaml.EditorExtras/RapidXamlEditorExtrasPackage.cs
+++ b/VSIX/RapidXaml.EditorExtras/RapidXamlEditorExtrasPackage.cs
@@ -17,7 +17,7 @@ namespace RapidXaml.EditorExtras
     [ProvideAutoLoad(UICONTEXT.CSharpProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideAutoLoad(UICONTEXT.VBProject_string, PackageAutoLoadFlags.BackgroundLoad)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "0.13.0")] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "0.13.1")] // Info on this package for Help/About
     [Guid(RapidXamlEditorExtrasPackage.PackageGuidString)]
     [ProvideOptionPage(typeof(EditorExtrasOptionsGrid), "Rapid XAML", "Editor", 106, 107, true)]
     [ProvideProfile(typeof(EditorExtrasOptionsGrid), "Rapid XAML", "Editor", 106, 107, true)]

--- a/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/IntraTextAdornmentTagger.cs
+++ b/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/IntraTextAdornmentTagger.cs
@@ -117,9 +117,8 @@ namespace RapidXaml.EditorExtras.SymbolVisualizer
                 {
                     ThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
-#pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-                        await this.view.VisualElement.Dispatcher.BeginInvoke(new Action(this.AsyncUpdate));
-#pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
+                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        this.AsyncUpdate();
                     });
                 }
             }

--- a/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/SymbolIconAdornmentTaggerProvider.cs
+++ b/VSIX/RapidXaml.EditorExtras/SymbolVisualizer/SymbolIconAdornmentTaggerProvider.cs
@@ -7,11 +7,12 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
+using RapidXamlToolkit;
 
 namespace RapidXaml.EditorExtras.SymbolVisualizer
 {
     [Export(typeof(IViewTaggerProvider))]
-    [ContentType("text")]
+    [ContentType(KnownContentTypes.Xaml)]
     [ContentType("projection")]
     [TagType(typeof(IntraTextAdornmentTag))]
     internal sealed class SymbolIconAdornmentTaggerProvider : IViewTaggerProvider

--- a/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
+++ b/VSIX/RapidXaml.EditorExtras/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.13.0" Language="en-US" Publisher="Matt Lacey" />
+    <Identity Id="RapidXaml.EditorExtras.07e87ef8-07f8-49fd-8f4b-f0958a539030" Version="0.13.1" Language="en-US" Publisher="Matt Lacey" />
     <DisplayName>Rapid XAML Editor Extras</DisplayName>
     <Description xml:space="preserve">Tools to accelerate XAML app development by providing additional features to the Visual Studio editor.</Description>
     <MoreInfo>https://github.com/mrlacey/Rapid-XAML-Toolkit</MoreInfo>


### PR DESCRIPTION
This PR relates to Issue #495

**Description**  
<!-- Please provide a brief description of what's being committed. -->

Fix VS UI lockup and display of this message:

![Dialog with an indeterminant progress bar and message "Please wait for an editor command to finish..." ](https://user-images.githubusercontent.com/189547/129921076-defe452c-38b8-4fc8-9b4d-e7342ea495a9.png)




**Confirm**
- [x] Everything builds in 'Release` mode
- [ ] Docs updated
- [x] Change log updated
- [x] All tests in RapidXamlToolkit.Tests passed
- [ ] If changes analysis or generation - all tests in [RapidXamlToolkit.Tests.Manual](https://github.com/mrlacey/Rapid-XAML-Toolkit/blob/main/docs/getting-started.md#vsixrapidxamltoolkiteverythingsln) passed

**Important points of note**  
<!-- Please identify anything that needs special attention or that the reviewer needs to be aware of. -->



